### PR TITLE
feat(controllers): add modifyPinStatus controller with integration tests

### DIFF
--- a/app/controllers/questions/modifyPinStatus.js
+++ b/app/controllers/questions/modifyPinStatus.js
@@ -1,0 +1,39 @@
+import { PIN_QUESTION_ERROR_MESSAGE, INVALID_PARAMS_FOR_OPERATION, QUESTION_NOT_FOUND } from "~/utils/backend/constants";
+import { modifyQuestionPinStatusParms } from "~/utils/backend/validators/question";
+import { db } from "~/utils/db.server";
+
+export const modifyPinStatus = async (questionId, newPinStatus) => {
+  const { error, value } = modifyQuestionPinStatusParms.validate({
+    questionId,
+    newPinStatus,
+  });
+
+  if (error) {
+    return { 
+      error: {
+        message: PIN_QUESTION_ERROR_MESSAGE,
+        detail: INVALID_PARAMS_FOR_OPERATION
+      }  
+    };
+  }
+
+  try {
+    const updatedQuestion = await db.Questions.update({
+      where: { question_id: value.questionId },
+      data: { is_pinned: value.newPinStatus },
+    });
+    return {
+      success: `The question has been ${updatedQuestion.is_pinned ? 'pinned' : 'unpinned'}`,
+      question: updatedQuestion,
+    }
+
+  } catch (error) {
+    return { 
+      error: {
+        message: PIN_QUESTION_ERROR_MESSAGE,
+        detail: QUESTION_NOT_FOUND
+      }  
+    };
+  }
+
+};

--- a/app/controllers/questions/modifyPinStatus.js
+++ b/app/controllers/questions/modifyPinStatus.js
@@ -1,4 +1,4 @@
-import { PIN_QUESTION_ERROR_MESSAGE, INVALID_PARAMS_FOR_OPERATION, QUESTION_NOT_FOUND } from "~/utils/backend/constants";
+import { PIN_QUESTION_ERROR_MESSAGE, INVALID_PARAMS_FOR_OPERATION_ERROR_MESSAGE, QUESTION_NOT_FOUND_ERROR_MESSAGE } from "~/utils/constants";
 import { modifyQuestionPinStatusParms } from "~/utils/backend/validators/question";
 import { db } from "~/utils/db.server";
 
@@ -12,7 +12,7 @@ export const modifyPinStatus = async (questionId, newPinStatus) => {
     return { 
       error: {
         message: PIN_QUESTION_ERROR_MESSAGE,
-        detail: INVALID_PARAMS_FOR_OPERATION
+        detail: INVALID_PARAMS_FOR_OPERATION_ERROR_MESSAGE
       }  
     };
   }
@@ -31,7 +31,7 @@ export const modifyPinStatus = async (questionId, newPinStatus) => {
     return { 
       error: {
         message: PIN_QUESTION_ERROR_MESSAGE,
-        detail: QUESTION_NOT_FOUND
+        detail: QUESTION_NOT_FOUND_ERROR_MESSAGE
       }  
     };
   }

--- a/app/utils/backend/constants.js
+++ b/app/utils/backend/constants.js
@@ -16,5 +16,8 @@ module.exports = {
   DEFAULT_OFFSET: 0,
   MIN_NET_PROMOTER_SCORE: 1,
   MAX_NET_PROMOTER_SCORE: 4,
-  DEFAULT_ERROR_MESSAGE: "An unknown error has occurred with your request."
+  DEFAULT_ERROR_MESSAGE: "An unknown error has occurred with your request.",
+  PIN_QUESTION_ERROR_MESSAGE: 'Error trying to pin/unpin the question.',
+  INVALID_PARAMS_FOR_OPERATION: 'The provided parameters for the operation are not valid',
+  QUESTION_NOT_FOUND: 'The question with the id provided could not be found',
 };

--- a/app/utils/backend/constants.js
+++ b/app/utils/backend/constants.js
@@ -17,7 +17,4 @@ module.exports = {
   MIN_NET_PROMOTER_SCORE: 1,
   MAX_NET_PROMOTER_SCORE: 4,
   DEFAULT_ERROR_MESSAGE: "An unknown error has occurred with your request.",
-  PIN_QUESTION_ERROR_MESSAGE: 'Error trying to pin/unpin the question.',
-  INVALID_PARAMS_FOR_OPERATION: 'The provided parameters for the operation are not valid',
-  QUESTION_NOT_FOUND: 'The question with the id provided could not be found',
 };

--- a/app/utils/backend/validators/question.js
+++ b/app/utils/backend/validators/question.js
@@ -10,3 +10,8 @@ export const createQuestionSchema = Joi.object().keys({
   created_by_employee_id: Joi.number().integer().min(1).allow(null),
   assigned_department: Joi.number().integer().min(1).allow(null),
 });
+
+export const modifyQuestionPinStatusParms = Joi.object().keys({
+  questionId: Joi.number().integer().required().min(1),
+  newPinStatus: Joi.boolean().required(),
+});

--- a/app/utils/constants.js
+++ b/app/utils/constants.js
@@ -318,3 +318,8 @@ export const RECOMMENDATIONS_QUESTION = [
   'Avoid posting questions that include sexually explicit comments, hate speech, prejudicial remarks, and profanity.',
   'Do not mock other members, their comments, profiles, threads, or experiences. Remember, what is funny for you may be offensive to others.',
 ];
+
+// Recurring error messages
+export const PIN_QUESTION_ERROR_MESSAGE = 'Error trying to pin/unpin the question.';
+export const  INVALID_PARAMS_FOR_OPERATION_ERROR_MESSAGE = 'The provided parameters for the operation are not valid';
+export const  QUESTION_NOT_FOUND_ERROR_MESSAGE = 'The question with the id provided could not be found';

--- a/tests/integration/controllers/questions/modifyPinStatus.test.js
+++ b/tests/integration/controllers/questions/modifyPinStatus.test.js
@@ -3,9 +3,9 @@ import { createQuestion } from "~/controllers/questions/create";
 import { randomAccessToken } from "./../../../utils";
 import {
   PIN_QUESTION_ERROR_MESSAGE,
-  INVALID_PARAMS_FOR_OPERATION,
-  QUESTION_NOT_FOUND,
-} from "~/utils/backend/constants";
+  INVALID_PARAMS_FOR_OPERATION_ERROR_MESSAGE,
+  QUESTION_NOT_FOUND_ERROR_MESSAGE,
+} from "~/utils/constants";
 import { db } from "~/utils/db.server";
 
 describe("questions controller", () => {
@@ -19,7 +19,7 @@ describe("questions controller", () => {
       expect(response.error.message).toBeDefined();
       expect(response.error.detail).toBeDefined();
       expect(response.error.message).toBe(PIN_QUESTION_ERROR_MESSAGE);
-      expect(response.error.detail).toBe(INVALID_PARAMS_FOR_OPERATION);
+      expect(response.error.detail).toBe(INVALID_PARAMS_FOR_OPERATION_ERROR_MESSAGE);
       expect(response.success).toBeUndefined();
       expect(response.question).toBeUndefined();
       expect(dbUpdateSpy).toHaveBeenCalledTimes(0);
@@ -32,7 +32,7 @@ describe("questions controller", () => {
       expect(response.error.message).toBeDefined();
       expect(response.error.detail).toBeDefined();
       expect(response.error.message).toBe(PIN_QUESTION_ERROR_MESSAGE);
-      expect(response.error.detail).toBe(INVALID_PARAMS_FOR_OPERATION);
+      expect(response.error.detail).toBe(INVALID_PARAMS_FOR_OPERATION_ERROR_MESSAGE);
       expect(response.success).toBeUndefined();
       expect(response.question).toBeUndefined();
       expect(dbUpdateSpy).toHaveBeenCalledTimes(0);
@@ -45,7 +45,7 @@ describe("questions controller", () => {
       expect(response.error.message).toBeDefined();
       expect(response.error.detail).toBeDefined();
       expect(response.error.message).toBe(PIN_QUESTION_ERROR_MESSAGE);
-      expect(response.error.detail).toBe(QUESTION_NOT_FOUND);
+      expect(response.error.detail).toBe(QUESTION_NOT_FOUND_ERROR_MESSAGE);
       expect(response.success).toBeUndefined();
       expect(response.question).toBeUndefined();
       expect(dbUpdateSpy).toHaveBeenCalledTimes(1);

--- a/tests/integration/controllers/questions/modifyPinStatus.test.js
+++ b/tests/integration/controllers/questions/modifyPinStatus.test.js
@@ -1,0 +1,86 @@
+import { modifyPinStatus } from "~/controllers/questions/modifyPinStatus";
+import { createQuestion } from "~/controllers/questions/create";
+import { randomAccessToken } from "./../../../utils";
+import {
+  PIN_QUESTION_ERROR_MESSAGE,
+  INVALID_PARAMS_FOR_OPERATION,
+  QUESTION_NOT_FOUND,
+} from "~/utils/backend/constants";
+import { db } from "~/utils/db.server";
+
+describe("questions controller", () => {
+  describe("Modify pin status of a question (modifyPinStatus)", () => {
+    const dbUpdateSpy = jest.spyOn(db.Questions, "update");
+
+    it("returns error when provided no parameters", async () => {
+      const response = await modifyPinStatus();
+
+      expect(response.error).toBeDefined();
+      expect(response.error.message).toBeDefined();
+      expect(response.error.detail).toBeDefined();
+      expect(response.error.message).toBe(PIN_QUESTION_ERROR_MESSAGE);
+      expect(response.error.detail).toBe(INVALID_PARAMS_FOR_OPERATION);
+      expect(response.success).toBeUndefined();
+      expect(response.question).toBeUndefined();
+      expect(dbUpdateSpy).toHaveBeenCalledTimes(0);
+    });
+
+    it("returns error when provided invalid parameters", async () => {
+      const response = await modifyPinStatus("test", 1);
+
+      expect(response.error).toBeDefined();
+      expect(response.error.message).toBeDefined();
+      expect(response.error.detail).toBeDefined();
+      expect(response.error.message).toBe(PIN_QUESTION_ERROR_MESSAGE);
+      expect(response.error.detail).toBe(INVALID_PARAMS_FOR_OPERATION);
+      expect(response.success).toBeUndefined();
+      expect(response.question).toBeUndefined();
+      expect(dbUpdateSpy).toHaveBeenCalledTimes(0);
+    });
+
+    it("throws error when question id not found", async () => {
+      const response = await modifyPinStatus(1000, true);
+
+      expect(response.error).toBeDefined();
+      expect(response.error.message).toBeDefined();
+      expect(response.error.detail).toBeDefined();
+      expect(response.error.message).toBe(PIN_QUESTION_ERROR_MESSAGE);
+      expect(response.error.detail).toBe(QUESTION_NOT_FOUND);
+      expect(response.success).toBeUndefined();
+      expect(response.question).toBeUndefined();
+      expect(dbUpdateSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("modifies the pin status to true successfully", async () => {
+      const question = {
+        question: "_This_ is a **sample** ~~question~~",
+        created_by_employee_id: 1,
+        accessToken: randomAccessToken(),
+        is_anonymous: false,
+        assigned_department: 3,
+        location: "BNK",
+      };
+
+      const createQuestionResponse = await createQuestion(question);
+
+      expect(createQuestionResponse).toBeDefined();
+      expect(createQuestionResponse.errors).toBeUndefined();
+      expect(createQuestionResponse.success).toBeDefined();
+      expect(createQuestionResponse.question).toBeDefined();
+      expect(createQuestionResponse.question.question_id).toBeDefined();
+      expect(createQuestionResponse.question.is_pinned).toBeDefined();
+      expect(createQuestionResponse.question.is_pinned).toBe(false);
+
+      const response = await modifyPinStatus(createQuestionResponse.question.question_id, true);
+
+      expect(response.error).toBeUndefined();
+      expect(response.success).toBeDefined();
+      expect(response.question).toBeDefined();
+      expect(response.success).toBe('The question has been pinned');
+      expect(response.question.is_pinned).toBeDefined();
+      expect(response.question.is_pinned).toBe(true);
+      expect(dbUpdateSpy).toHaveBeenCalledTimes(2);
+    });
+    
+  });
+});


### PR DESCRIPTION
#### What does this PR do?
It adds the 'modifyPinStatus' controller to pin/unpin a question, if the question update is successful, it returns the updated question with a success message. If there's an error, an object with an error property is returned.

#### Where should the reviewer start?
- controllers/questions/modifyPinStatus.js
- tests/integration/controllers/questions/modifyPinStatus.test.js

#### How should this be manually tested?
The integration tests added are passing at the moment.

#### Any background context you want to provide?

#### What are the relevant tickets?
(Link to issues, related PR, JIRA issues, etc.)
Closes #8 

#### Screenshots

#### Questions