### PR TITLE
feat(home): initial list questions page view

### DIFF
--- a/app/components/AnswerAdminOptions/AnswerAdminOptions.Styled.jsx
+++ b/app/components/AnswerAdminOptions/AnswerAdminOptions.Styled.jsx
@@ -33,7 +33,7 @@ export const AnswerOptions = styled.div`
 `;
 
 export const OptionsTooltip = styled.div`
-  font-family: 'NunitoSans Regular', sans-serif;
+  font-family: 'Nunito', sans-serif;
   background-color: #31425a;
   border-radius: 6px;
   bottom: 150%;

--- a/app/components/AnswerRow/AnswerRow.Styled.jsx
+++ b/app/components/AnswerRow/AnswerRow.Styled.jsx
@@ -2,7 +2,7 @@ import styled, { css } from 'styled-components';
 import Markdown from 'react-markdown';
 
 export const AnswerRow = styled.div` 
-  font-family: 'NunitoSans Regular', sans-serif;
+  font-family: 'Nunito', sans-serif;
   font-size: 14px;
   letter-spacing: 0.6px;
   line-height: 1.71;
@@ -29,7 +29,8 @@ export const AnswerMarkdown = styled(Markdown)`
 
 export const AnswerContainer = styled.div`
   width: 100%;
-  padding: 30px 0 0 50px;
+  margin-top: 20px;
+
   @media screen and (max-width: 480px) {
     margin-top: 20px;
     padding: 0 20px;
@@ -70,11 +71,11 @@ export const AnsweredMetadata = styled.div`
   `}
 `;
 
-export const AnswerMetadataBottom = styled.div`
+export const AnswerRowDate = styled.div`
   color: var(--color-dark-25);
   display: flex;
   flex-direction: column;
-  font-family: "NunitoSans SemiBold",sans-serif;
+  font-family: "Nunio",sans-serif;
   font-size: 12px;
   align-items: end;
   letter-spacing: 0.7px;
@@ -83,6 +84,7 @@ export const AnswerMetadataBottom = styled.div`
 `;
 
 export const AnswerRowLineVertical = styled.div`
+  display: none;
   position: absolute;
   height: 65px;
   border-right: 1px solid var(--color-dark-25);
@@ -97,6 +99,7 @@ export const AnswerRowLineVertical = styled.div`
 `;
 
 export const AnswerRowLineHorizontal = styled.div`
+  display: none;
   position: absolute;
   width: 20px;
   border-top: 1px solid var(--color-dark-25);
@@ -111,7 +114,6 @@ export const AnswerRowLineHorizontal = styled.div`
 `;
 
 export const AnswerRowBorderBottom = styled.div`
-  border-bottom: var(--color-dark-25) solid 1px;
   margin-top: 8px;
   width: 100%;
 `;

--- a/app/components/AnswerRow/AnswerRow.jsx
+++ b/app/components/AnswerRow/AnswerRow.jsx
@@ -13,21 +13,20 @@ import QuestionResponderInfo from '~/components/QuestionResponderInfo';
 import Button from '~/components/Atoms/Button';
 
 function AnswerRow({ searchTerm, isPreview, isQuestionModalOpen, ...props }) {
-  const shouldCollapse = () => props.answer.length > COLLAPSED_ANSWER_MIN_LENGTH;
+  const shouldCollapse = () => props.answer_text.length > COLLAPSED_ANSWER_MIN_LENGTH;
   const [collapsed, setCollapsed] = useState(shouldCollapse);
 
   const renderAnswer = () => (
     <Styled.AnswerRow>
       <ConditionalLinkTo to={`/question/${props.questionId}`} condition={props.isFromList}>
         <Styled.AnswerMarkdown
-          source={formatCollapsingText(
-          markdownFormat(props.answer, searchTerm),
+          children={formatCollapsingText(
+          markdownFormat(props.answer_text, searchTerm),
           shouldCollapse(),
           collapsed,
           COLLAPSED_ANSWER_MIN_LENGTH,
         )}
-          escapeHtml={false}
-          renderers={{ link: MarkdownLinkRenderer }}
+          components={{ link: MarkdownLinkRenderer }}
         />
       </ConditionalLinkTo>
       {shouldCollapse() && (
@@ -39,7 +38,7 @@ function AnswerRow({ searchTerm, isPreview, isQuestionModalOpen, ...props }) {
     </Styled.AnswerRow>
   );
 
-  const { user, answered_at: answeredAt, children } = props;
+  const { user, createdAt, children } = props;
   return (
     <Styled.AnswerContainer isPreview={isPreview} isQuestionModalOpen={isQuestionModalOpen}>
       <Styled.AnsweredMetadata isPreview={isPreview}>
@@ -48,26 +47,25 @@ function AnswerRow({ searchTerm, isPreview, isQuestionModalOpen, ...props }) {
         <ConditionalLinkTo to={`/question/${props.questionId}`} condition={props.isFromList}>
           <QuestionResponderInfo department={'Best Answer'} createdBy={user} isAnswer />
         </ConditionalLinkTo>
+        <Styled.AnswerRowDate isQuestionModalOpen={isQuestionModalOpen}>
+          {getFormattedDate(createdAt)}
+        </Styled.AnswerRowDate>
         {children}
       </Styled.AnsweredMetadata>
       {renderAnswer({ isQuestionModalOpen })}
-      <Styled.AnswerMetadataBottom isQuestionModalOpen={isQuestionModalOpen}>
-        {getFormattedDate(answeredAt)}
-        <Styled.AnswerRowBorderBottom />
-      </Styled.AnswerMetadataBottom>
     </Styled.AnswerContainer>
   );
 }
 
 AnswerRow.propTypes = {
-  answer: PropTypes.string.isRequired,
+  answer_text: PropTypes.string.isRequired,
   user: PropTypes.shape({
     email: PropTypes.string.isRequired,
     full_name: PropTypes.string.isRequired,
     profile_picture: PropTypes.string.isRequired,
     job_title: PropTypes.string,
   }).isRequired,
-  answered_at: PropTypes.string.isRequired,
+  createdAt: PropTypes.string.isRequired,
   children: PropTypes.node.isRequired,
   searchTerm: PropTypes.string,
   isPreview: PropTypes.bool,

--- a/app/components/AppNavbar/AppNavbar.jsx
+++ b/app/components/AppNavbar/AppNavbar.jsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { Navbar } from 'react-bootstrap';
-import { Link } from 'react-router-dom';
 import logo from '~/images/logo.png';
+import { Link } from '@remix-run/react';
 import * as Styled from '~/components/AppNavbar/AppNavbar.Styled';
 import UserControls from '~/components/UserControls';
 import { useUser } from '~/utils/hooks/useUser';

--- a/app/components/Atoms/ConditionalLinkTo/ConditionalLinkTo.jsx
+++ b/app/components/Atoms/ConditionalLinkTo/ConditionalLinkTo.jsx
@@ -1,5 +1,5 @@
+import { Link } from '@remix-run/react';
 import PropTypes from 'prop-types';
-import { Link } from 'react-router-dom';
 
 function ConditionalLinkTo({ children, to, condition }) {
   if (condition) {

--- a/app/components/Atoms/InfiniteScrollList/InfiniteScrollList.jsx
+++ b/app/components/Atoms/InfiniteScrollList/InfiniteScrollList.jsx
@@ -12,19 +12,21 @@ function InfiniteScrollList({ onFetch, children }) {
       onFetch();
     }
   };
-  const observer = new IntersectionObserver(onScroll, {
-    root: scrollContainer,
-    rootMargin: `${fetchScrollLimit}px`,
-    threshold: 0,
-  });
+
+  const observer = useRef();
 
   useEffect(() => {
+    observer.current = new IntersectionObserver(onScroll, {
+      root: scrollContainer,
+      rootMargin: `${fetchScrollLimit}px`,
+      threshold: 0,
+    });
     if (endOfListRef && endOfListRef.current) {
-      observer.observe(endOfListRef.current);
+      observer.current.observe(endOfListRef.current);
     }
     return () => {
       if (endOfListRef && endOfListRef.current) {
-        observer.unobserve(endOfListRef.current);
+        observer.current.unobserve(endOfListRef.current);
       }
     };
   }, [children.props.children.length]);

--- a/app/components/CounterButton/CounterButton.Styled.jsx
+++ b/app/components/CounterButton/CounterButton.Styled.jsx
@@ -9,7 +9,7 @@ const handleColorType = (props) => {
   return '#31425a';
 };
 
-export const CounterButton = styled.button`
+export const ContainerCounterButton = styled.button`
   align-items: center;
   background-color: transparent;
   border: none;
@@ -18,7 +18,7 @@ export const CounterButton = styled.button`
   cursor: pointer;
   display: inline-flex;
   flex-direction: row;
-  font-family: "NunitoSans Regular", sans-serif;
+  font-family: "Nunito", sans-serif;
   font-size: 14px;
   font-weight: 600;
   justify-content: center;
@@ -40,7 +40,7 @@ export const CounterButton = styled.button`
   }
 `;
 
-export const CounterButtonNotMobile = styled.div`
+export const ContainerCounterButtonNotMobile = styled.div`
   display: unset;
   @media screen and (max-width: 768px) {
     display: none;

--- a/app/components/CounterButton/CounterButton.jsx
+++ b/app/components/CounterButton/CounterButton.jsx
@@ -4,7 +4,7 @@ import * as Styled from './CounterButton.Styled';
 
 const CounterButton = ({ icon, text, count, selected, onClick, notButton }) => {
   const validIcon = React.isValidElement(icon);
-  return (<Styled.CounterButton
+  return (<Styled.ContainerCounterButton
     onClick={onClick}
     selected={selected}
     notButton={notButton}
@@ -15,12 +15,12 @@ const CounterButton = ({ icon, text, count, selected, onClick, notButton }) => {
       {count}
       {
         text &&
-        (<Styled.CounterButtonNotMobile>
+        (<Styled.ContainerCounterButtonNotMobile>
           &nbsp;{text}
-        </Styled.CounterButtonNotMobile>)
+        </Styled.ContainerCounterButtonNotMobile>)
       }
     </span>
-  </Styled.CounterButton>);
+  </Styled.ContainerCounterButton>);
 };
 
 CounterButton.defaultProps = {

--- a/app/components/CustomDropdown/CustomDropdown.Styled.jsx
+++ b/app/components/CustomDropdown/CustomDropdown.Styled.jsx
@@ -4,6 +4,7 @@ import { Dropdown, MenuItem } from 'react-bootstrap';
 export const CDropdown = styled(Dropdown)`
   .dropdown-menu {
     top: 98%;
+    background-color: transparent;
   }
   .dropdown-menu > .sub-menu-item > a {
     line-height: 20px;
@@ -11,6 +12,10 @@ export const CDropdown = styled(Dropdown)`
   }
   .dropdown-menu a {
     text-decoration: none;
+    border-radius 10px;
+    &:hover {
+      background-color: #F1F3F6;
+    }
   }
   .dropdown-menu li {
     height: auto;

--- a/app/components/Filters/Filters.Styled.jsx
+++ b/app/components/Filters/Filters.Styled.jsx
@@ -1,8 +1,7 @@
 import styled, { css } from 'styled-components';
 
-
 export const Filters = styled.div`
-  background-color: #f4f7f9;
+  background-color: transparent;
   margin: 0 11px;
   position: -webkit-sticky;
   position: sticky;
@@ -60,14 +59,11 @@ export const FiltersWrapper = styled.div`
       width: 248px;
   }
   #sort-toggle.dropdown-toggle.btn {
-    background: #fff;
+    background-color: transparent;
     border: none;
     font-size: 14px;
     height: 56px;
     width: 100%;
-    &:hover {
-      background-color: #ecf7ff;
-    }
   }
 `;
 
@@ -81,11 +77,14 @@ export const FiltersLabel = styled.div`
   font-size: 12px;
   margin: 8px 0 4px;
   width: auto;
-  a {
+  button {
     color: var(--color-secondary);
     float: right;
     font-size: 12px;
     text-decoration: none;
+    background: none!important;
+    border: none;
+    padding: 0!important;
   }
 `;
 
@@ -95,9 +94,7 @@ export const FiltersField = styled.div`
   flex-wrap: wrap;
   font-size: 12px;
   .sort-toggle.dropdown {
-    border: 1px solid #e1e5e9;
-    border-radius: 5px;
-    box-shadow: 0 2px 4px 0 rgba(225, 229, 233, 0.8);
+    border-radius: 10px;
     margin: 8px 0;
     width: 100%;
   }
@@ -115,6 +112,9 @@ export const FiltersField = styled.div`
     -webkit-transform: scale(1, -1);
     transform: scale(1, -1);
   }
+  .dropdown:hover {
+    background-color: transparent;
+  }
   .dropdown .menu-dropdown {
     box-shadow: none;
     margin: 0;
@@ -123,15 +123,7 @@ export const FiltersField = styled.div`
   }
   .dropdown.open .menu-dropdown {
     border: none;
-    box-shadow: 0 3px 6px 0 rgba(225, 229, 233, 0.8);
-    display: inline-table;
-    padding: 5px 0 8.9px;
-    position: unset;
-  }
-  .dropdown.open .menu-dropdown {
-    border: none;
-    box-shadow: 0 3px 6px 0 rgba(225, 229, 233, 0.8);
-    display: inline-table;
+    border-radius: 10px;
     padding: 5px 0 8.9px;
     position: unset;
   }

--- a/app/components/GoToTopButton/GoToTopButton.Styled.jsx
+++ b/app/components/GoToTopButton/GoToTopButton.Styled.jsx
@@ -31,7 +31,7 @@ export const Button = styled.button`
 
 export const Span = styled.span`
   color: #ffffff;
-  font-family: 'NunitoSans Regular', sans-serif;
+  font-family: 'Nunito', sans-serif;
   font-size: 14px;
   font-weight: 600;
   letter-spacing: 0.58px;

--- a/app/components/ListQuestions/ListQuestions.Styled.jsx
+++ b/app/components/ListQuestions/ListQuestions.Styled.jsx
@@ -1,32 +1,53 @@
-
-
+import { Link } from '@remix-run/react';
 import styled from 'styled-components';
 
 export const Container = styled.div`
-  display: grid;
+  display: flex;
   background-color: #f4f7f9;
-  grid-template-areas: "top top top" "left center right";
-  grid-template-columns: 25% 50% 25%;
   margin: 0 auto;
-  max-width: 1280px;
   width: 100%;
+  max-width: 1600px;
   padding-top: 40px;
-  @media (min-width: 768px) and (max-width: 1024px) {
-    grid-template-areas: "top top top" "filters filters filters" "left center right";
-    grid-template-columns: 0 100% 0;
+  @media (max-width: 1025px) {
+    flex-direction: column-reverse;
+    align-items: center;
   }
-  @media (max-width: 767px) {
-    grid-template-areas: "top top top" "filters filters filters" "left center right";
-    grid-template-columns: 0 100% 0;
-    padding-top: 10px;
+  @media (max-width: 768px) {
+    padding-top: 20px;
+  }
+`;
+
+export const LeftWrapper = styled.div`
+  flex: 1;
+`;
+
+export const CenterWrapper = styled.div`
+  flex: 2;
+  display: flex;
+  justify-content: center;
+`;
+
+export const RightWrapper = styled.div`
+  flex: 1;
+  display: flex;
+  @media (max-width: 1025px) {
+    width: 100%;
+    display: contents;
+    position: sticky;
   }
 `;
 
 export const SloganWrapper = styled.div`
-  grid-area: left;
+  max-width: 425px;
+  
   @media (max-width: 1025px) {
     display: none;
   }
+`;
+
+export const QuestionsWrapper = styled.div`
+  max-width: 650px;
+  width: 100%;
 `;
 
 export const AskQuestionButtonWrapper = styled.div`
@@ -35,17 +56,15 @@ export const AskQuestionButtonWrapper = styled.div`
   flex-direction: row;
   display: flex;
   justify-content: space-between;
+  margin-bottom: 20px;
 `;
 
 export const QuestionsTitle = styled.div`
-  font-family: "NunitoSans Bold", sans-serif;
+  align-items: center;
+  display: flex;
+  font-family: "Nunito", sans-serif;
   font-size: 20px;
   letter-spacing: 0.6px;
-  padding-top: 10px;
-`;
-
-export const QuestionsWrapper = styled.div`
-  grid-area: center;
 `;
 
 export const QuestionList = styled.div`
@@ -54,7 +73,6 @@ export const QuestionList = styled.div`
 `;
 
 export const Alert = styled.div`
-  grid-area: center;
   border-radius: 3px;
   margin: 0 auto;
   max-width: 592px;
@@ -66,20 +84,44 @@ export const Alert = styled.div`
 `;
 
 export const FiltersWrapper = styled.div`
-  grid-area: right;
-  background-color: #f4f7f9;
+  width: 100%;
+  max-width: 300px;
   @media (max-width: 1024px) {
-    grid-area: filters;
+    max-width: none;
+    padding: 0 0 20px;
+    position: -webkit-sticky;
+    position: sticky;
+    top: 0;
+    background-color: #f4f7f9;
+    border-radius: 18px;
+  }
+  @media (max-width: 767px) {
     padding: 0 0 20px;
     position: -webkit-sticky;
     position: sticky;
     top: 0;
   }
-  @media (max-width: 767px) {
-    grid-area: filters;
-    padding: 0 0 20px;
-    position: -webkit-sticky;
-    position: sticky;
-    top: 0;
+`;
+
+export const AskButton = styled(Link)`
+  align-items: center;
+  background: var(--color-secondary);
+  border: solid 1px transparent;
+  border-radius: 3px;
+  color: #fff;
+  display: flex;
+  height: 33px;
+  justify-content: center;
+  padding: 20px 15px;
+  text-decoration: none;
+  width: 120px;
+  &:disabled {
+    background: #d8d8d8;
+  }
+  &:hover {
+    background-color: white;
+    border: solid 1px var(--color-secondary);
+    color: var(--color-secondary);
+    text-decoration: none;
   }
 `;

--- a/app/components/ListQuestions/ListQuestions.jsx
+++ b/app/components/ListQuestions/ListQuestions.jsx
@@ -1,81 +1,33 @@
-import { useEffect, useRef, useState } from 'react';
+import { useState } from 'react';
 
 import PropTypes from 'prop-types';
 import * as Styled from './ListQuestions.Styled';
 import {
-  DEFAULT_DEPARTMENT_ID,
-  DEFAULT_LOCATION,
   FILTER_BY_USER_TEXT,
   FILTER_BY_USER_TYPES,
-  PAGE_QUESTIONS_LIMIT,
-  PRIMARY_BUTTON,
 } from '~/utils/constants';
 import Slogan from '~/components/Slogan';
-import Button from '~/components/Atoms/Button';
 import QuestionCard from '~/components/QuestionCard';
 import { useUser } from '~/utils/hooks/useUser';
 import GoToTopButton from '~/components/GoToTopButton';
 import markdownFormatQuestion from '~/utils/markdownFormatQuestions';
 import InfiniteScrollList from '~/components/Atoms/InfiniteScrollList';
-import { Link } from '@remix-run/react';
 import Filters from '~/components/Filters';
+import { useSearchParams } from '@remix-run/react';
 
-const ListQuestions = (props) => {
+const ListQuestions = ({
+  questions,
+  onFetchMore,
+}) => {
   const profile = useUser();
+  const [searchParams, setSearchParams] = useSearchParams();
 
-  const {
-    type,
-    search,
-    questions,
-    currentQuestion,
-    getQuestionById,
-    fetchMoreQuestions,
-    fetchQuestions,
-  } = props;
-
-  const initialState = {
-    initiated: false,
-    questionVotes: {},
-    searchTerm: '',
-    showAnswerModal: false,
-    showAssignAnswerModal: false,
-    showQuestionModal: false,
-    showDeleteAnswerModal: false,
-    question: {},
-    filterByUserEnum: FILTER_BY_USER_TYPES,
-    filterByUserText: FILTER_BY_USER_TEXT,
-    open: false,
-    answerCollapsing: {},
-  };
-
-  const [state, setState] = useState(initialState);
   const [title, setTitle] = useState('Newest Questions');
 
-  const fetchQuestionsQuery = useRef({
-    type,
-    offset: 0,
-    order: '',
-    dateRange: '',
-    status: '',
-    search: '',
-    limit: PAGE_QUESTIONS_LIMIT,
-    location: DEFAULT_LOCATION,
-    filterByUser: false,
-    tag: '',
-    departmentId: DEFAULT_DEPARTMENT_ID,
-  });
-
-  const callFetchQuestions = () => {
-    fetchQuestions(fetchQuestionsQuery.current);
+  //TODO: Implement search
+  const state = {
+    searchTerm: undefined,
   };
-
-  const checkQuestionIdParams = () => {
-    // const query = parse(search) || {};
-    // if (query.questionId) {
-    //   getQuestionById(query.questionId);
-    // }
-  };
-
 
   const decorateQuestion = question => ({
     ...question,
@@ -83,9 +35,15 @@ const ListQuestions = (props) => {
     hasVoted: !!question.hasVoted,
   });
 
+  const clearFilters = (params) => {
+    params.forEach((param) => {
+      searchParams.delete(param);
+    });
+
+    setSearchParams(searchParams);
+  };
 
   const modifyQuery = (field, value) => {
-    fetchQuestionsQuery.current[field] = value;
     if (field === 'order') {
       if (value === 'oldest') {
         setTitle('Oldest Questions');
@@ -97,6 +55,14 @@ const ListQuestions = (props) => {
         setTitle('Most Commented Questions');
       }
     }
+
+    if (value === undefined) {
+      searchParams.delete(field);
+    } else {
+      searchParams.set(field, value);
+    }
+    setSearchParams(searchParams);
+
   };
 
   const displayUsername = (user) => {
@@ -111,15 +77,6 @@ const ListQuestions = (props) => {
     return answeredBy;
   };
 
-  const callFetchMoreQuestions = () => {
-    const offset = questions.length;
-    fetchMoreQuestions({
-      ...fetchQuestionsQuery.current,
-      offset,
-    });
-  };
-
-
   const renderQuestionsList = () => {
     if (questions.length === 0) { return null; }
 
@@ -132,7 +89,7 @@ const ListQuestions = (props) => {
         displayAnsweredBy={displayAnsweredBy}
         searchTerm={state.searchTerm}
         index={index}
-        fetchQuestionsList={callFetchQuestions}
+        onVoteClick={() => console.log("vote")}
       />
     ));
   };
@@ -141,105 +98,67 @@ const ListQuestions = (props) => {
     if (state.searchTerm) {
       return 'Oops! There are no results for your search';
     }
-    if (!questions && type.match(/all/i)) {
+    if (!questions) {
       return 'Loading questions...';
     }
     return 'There are no questions yet, how about asking one?';
   };
 
   const generateAskQuestionButton = () => (
-    <Button
-      id="ask-question-btn"
-      type="button"
-      category={PRIMARY_BUTTON}
-      className="ask-question-button"
-    >
-    Ask Question
-    </Button>
+    <Styled.AskButton to="/questions/new">
+      Ask Question
+    </Styled.AskButton>
      );
-
-  useEffect(() => {
-    // if (!state.initiated) {
-    //   const query = parse(search) || {};
-    //   fetchQuestionsQuery.current.tag = query.tag || '';
-    //   callFetchQuestions();
-    //   checkQuestionIdParams();
-
-    //   setState({
-    //     ...state,
-    //     initiated: true,
-    //   });
-    // } else if (currentQuestion && currentQuestion.question_id) {
-    //   setState({
-    //     ...state,
-    //     question: currentQuestion,
-    //     showQuestionModal: true,
-    //   });
-    // }
-  }, [currentQuestion]);
-
+    
   return (
     <Styled.Container>
       {/* TODO: Add left hashtag's panel */}
-      <Styled.SloganWrapper>
-        <Slogan />
-      </Styled.SloganWrapper>
-      <Styled.QuestionsWrapper>
-        <Styled.AskQuestionButtonWrapper>
-          <Styled.QuestionsTitle>
-            {title}
-          </Styled.QuestionsTitle>
-          <Link to="/question">
+      <Styled.LeftWrapper>
+        <Styled.SloganWrapper>
+          <Slogan />
+        </Styled.SloganWrapper>
+      </Styled.LeftWrapper>
+      <Styled.CenterWrapper>
+        <Styled.QuestionsWrapper>
+          <Styled.AskQuestionButtonWrapper>
+            <Styled.QuestionsTitle>
+              {title}
+            </Styled.QuestionsTitle>
             {generateAskQuestionButton()}
-          </Link>
-        </Styled.AskQuestionButtonWrapper>
-        {questions.length === 0 ? (
-          <Styled.Alert>{renderNoResultMessage()}</Styled.Alert>
-          ) : (
-            <InfiniteScrollList onFetch={callFetchMoreQuestions}>
-              <Styled.QuestionList>
-                {renderQuestionsList(questions)}
-              </Styled.QuestionList>
-            </InfiniteScrollList>
-          )}
-      </Styled.QuestionsWrapper>
-      <Styled.FiltersWrapper>
-        <Filters
-          callFetchQuestions={callFetchQuestions}
-          modifyQuery={modifyQuery}
-        />
-      </Styled.FiltersWrapper>
+          </Styled.AskQuestionButtonWrapper>
+          {questions.length === 0 ? (
+            <Styled.Alert>{renderNoResultMessage()}</Styled.Alert>
+            ) : (
+              <InfiniteScrollList onFetch={onFetchMore}>
+                <Styled.QuestionList>
+                  {renderQuestionsList(questions)}
+                </Styled.QuestionList>
+              </InfiniteScrollList>
+            )}
+        </Styled.QuestionsWrapper>
+      </Styled.CenterWrapper>
+      <Styled.RightWrapper>
+        <Styled.FiltersWrapper>
+          <Filters
+            modifyQuery={modifyQuery}
+            clearFilters={clearFilters}
+          />
+        </Styled.FiltersWrapper>
+      </Styled.RightWrapper>
       <GoToTopButton />
     </Styled.Container>
   );
-};
-
-ListQuestions.contextTypes = {
-  router: PropTypes.object,
 };
 
 ListQuestions.propTypes = {
   questions: PropTypes.arrayOf(
     PropTypes.shape(),
   ),
-  currentQuestion: PropTypes.shape(),
-  profile: PropTypes.shape({
-    email: PropTypes.string,
-  }).isRequired,
-  type: PropTypes.string,
-  fetchQuestions: PropTypes.func.isRequired,
-  fetchMoreQuestions: PropTypes.func.isRequired,
-  voteSocketQuestion: PropTypes.func.isRequired,
-  search: PropTypes.string,
-  getQuestionById: PropTypes.func.isRequired,
+  onFetchMore: PropTypes.func.isRequired,
 };
 
 ListQuestions.defaultProps = {
   questions: [],
-  currentQuestion: {},
-  type: '',
-  isValidProfile: false,
-  search: null,
 };
 
 

--- a/app/components/QuestionCard/QuestionCard.Styled.jsx
+++ b/app/components/QuestionCard/QuestionCard.Styled.jsx
@@ -52,6 +52,8 @@ export const QuestionCardActions = styled.div`
 export const CounterButtonsWrapper = styled.div`
   justify-content: space-between;
   width: 100%;
+  display: inline-flex;
+
   ${props => props.isAdmin && !props.hasAnswer && css`
     justify-content: flex-start;
   `}

--- a/app/components/QuestionCard/QuestionCard.jsx
+++ b/app/components/QuestionCard/QuestionCard.jsx
@@ -10,7 +10,7 @@ import {
 import * as Styled from './QuestionCard.Styled';
 import { useNavigate } from 'react-router-dom';
 import QuestionRow from '~/components/QuestionRow';
-import { CounterButton } from '~/components/CounterButton/CounterButton.Styled';
+import CounterButton from '~/components/CounterButton';
 
 const QuestionCard = (props) => {
   const {
@@ -43,12 +43,12 @@ const QuestionCard = (props) => {
     const icon = !question.hasVoted ? likeIcon : likeIconVoted;
 
     return (
-      <Styled.CounterButtonsWrapper className="question-row__counter-buttons--container" isAdmin={false} hasAnswer={hasAnswer}>
+      <Styled.CounterButtonsWrapper isAdmin={false} hasAnswer={hasAnswer}>
         <CounterButton
           selected={question.hasVoted}
           icon={icon}
-          text={addS('Like', question.Votes)}
-          count={question.Votes}
+          text={addS('Like', question.num_votes)}
+          count={question.num_votes}
           onClick={() => onVoteClick(question)}
         />
         <CounterButton
@@ -105,14 +105,12 @@ QuestionCard.propTypes = {
     }),
     createdAt: PropTypes.string.isRequired,
     location: PropTypes.string.isRequired,
-    Votes: PropTypes.number.isRequired,
     numComments: PropTypes.number.isRequired,
     hasVoted: PropTypes.bool.isRequired,
   }).isRequired,
   onVoteClick: PropTypes.func.isRequired,
   currentUserEmail: PropTypes.string,
   searchTerm: PropTypes.string,
-  fetchQuestionsList: PropTypes.func.isRequired,
 };
 
 QuestionCard.defaultProps = {

--- a/app/components/QuestionMarkdown/QuestionMarkdown.Styled.jsx
+++ b/app/components/QuestionMarkdown/QuestionMarkdown.Styled.jsx
@@ -3,7 +3,7 @@ import Markdown from 'react-markdown';
 
 export const QuestionMarkdown = styled(Markdown)`
   color: var(--color-dark-50);
-  font-family: "NunitoSans Regular";
+  font-family: "Nunito";
   font-size: 14px;
   letter-spacing: 0.6px;
   line-height: 1.71;

--- a/app/components/QuestionMarkdown/QuestionMarkdown.jsx
+++ b/app/components/QuestionMarkdown/QuestionMarkdown.jsx
@@ -1,16 +1,15 @@
 import PropTypes from 'prop-types';
-import * as Styled from './QuestionMarkdown.styled';
+import * as Styled from './QuestionMarkdown.Styled';
 import gfm from 'remark-gfm';
 import MarkdownLinkRenderer from '~/components/MarkdownLinkRenderer';
 
 const QuestionMarkdown = props => (
   <Styled.QuestionMarkdown
-    source={props.source}
-    escapeHtml={false}
-    renderers={{
+    children={props.source}
+    components={{
       link: MarkdownLinkRenderer,
     }}
-    plugins={[gfm]}
+    remarkPlugins={[gfm]}
   />
 );
 

--- a/app/components/QuestionResponderInfo/QuestionResponderInfo.Styled.jsx
+++ b/app/components/QuestionResponderInfo/QuestionResponderInfo.Styled.jsx
@@ -16,7 +16,7 @@ export const QuestionerResponderContainer = styled.div`
 `;
 
 export const QuestionerResponderInfoContainer = styled.div`
-  font-family: "NunitoSans Regular", sans-serif;
+  font-family: "Nunito", sans-serif;
   font-size: 12px;
   margin-left: 8px;
 `;
@@ -26,7 +26,7 @@ export const QuestionResponderDepartment = styled.div`
   border-radius: 20px;
   border: 2px solid var(--color-secondary);
   color: var(--color-secondary);
-  font-family: 'NunitoSans Bold', sans-serif;
+  font-family: 'Nunito', sans-serif;
   font-size: 14px;
   line-height: normal;
   margin-top: 5px;
@@ -42,7 +42,7 @@ export const QuestionResponderDepartment = styled.div`
 `;
 
 export const QuestionerResponderName = styled.span`
-  font-family: "NunitoSans Semibold", sans-serif;
+  font-family: "Nunito", sans-serif;
   font-size: 18px;
   letter-spacing: 0.5px;
   @media screen and (max-width: 768px) {

--- a/app/components/QuestionRow/QuestionRow.Styled.jsx
+++ b/app/components/QuestionRow/QuestionRow.Styled.jsx
@@ -38,7 +38,7 @@ export const QuestionRowOptions = styled.div`
   margin-right: 10px;
   > span:first-child {
     color: #a2abaf;
-    font-family: "NunitoSans Regular", sans-serif;
+    font-family: "Nunito", sans-serif;
     font-size: 12px;
     margin-bottom: 2px;
   }
@@ -58,6 +58,7 @@ export const PinQuestionIconHolder = styled.span`
   }
 `;
 
+
 export const PinActionableIconHolder = styled.img`
   margin-right: 0px;
   margin-top: 0px;
@@ -69,6 +70,27 @@ export const PinActionableIconHolder = styled.img`
   width: 16px;
   filter: invert(28%) sepia(8%) saturate(331%) hue-rotate(169deg) brightness(97%) contrast(82%);
 `;
+
+export const PinTooltipMessage = styled.span`
+  display: none;
+  width: 210px;
+  background-color: black;
+  color: #fff;
+  text-align: center;
+  border-radius: 6px;
+  padding: 8px 0px;
+  position: absolute;
+  z-index: 1000;
+  right: 25px;
+  top: -25px;
+  font-size: 11px;
+  letter-spacing: 0.5px;
+
+  ${PinQuestionIconHolder}:hover & {
+    display: block;
+  }
+`
+
 
 export const UnpinActionableIconHolder = styled.img`
   margin-right: 0px;
@@ -83,13 +105,13 @@ export const UnpinActionableIconHolder = styled.img`
 `;
 
 export const PinnedIndicator = styled.span`
-  margin-right: 10px;
   float: right;
   display: flex;
   flex-direction: row;
   justify-content: space-between;
+  height: fit-content;
+
   > img {
-    margin-top: 4px;
     display: block;
     display: block;
     margin-left: 5px;
@@ -101,9 +123,8 @@ export const PinnedIndicator = styled.span`
   }
   > span {
     min-width: 80px;
-    margin-top: 6px;
     color: var(--color-dark-25);
-    font-family: "NunitoSans SemiBold", sans-serif;
+    font-family: "Nunito", sans-serif;
     font-size: 11px;
     letter-spacing: 0.7px;
     @media screen and (max-width: 480px) {
@@ -114,9 +135,6 @@ export const PinnedIndicator = styled.span`
 
 export const QuestionRowWrapper = styled.div`
     width: 100%;
-    ${props => props.hasAnswer && css`
-        padding-left: 55px;
-    `}
 `;
 
 export const QuestionRowContent = styled.div`
@@ -128,7 +146,7 @@ export const QuestionRowContent = styled.div`
 export const QuestionRowMetadataBottom = styled.div`
   color: var(--color-dark-25);
   display: flex;
-  font-family: "NunitoSans SemiBold", sans-serif;
+  font-family: "Nunito", sans-serif;
   font-size: 12px;
   justify-content: space-between;
   letter-spacing: 0.7px;
@@ -143,6 +161,7 @@ export const QuestionRowBorderBottom = styled.div`
 `;
 
 export const QuestionRowLine = styled.div`
+    display: none;
     border-right: 1px solid var(--color-dark-25);
     height: 95%;
     left: 22px;
@@ -156,4 +175,31 @@ export const QuestionRowLine = styled.div`
     ${props => (!props.hasAnswer || props.isQuestionModalOpen) && css`
         display: none
     `}
+`;
+
+export const QuestionRowDate = styled.div`
+    display: flex;
+    height: fit-content;
+    color: var(--color-dark-25);
+    font-family: "Nunito", sans-serif;
+    font-size: 12px;
+    letter-spacing: 0.7px;
+    margin-bottom: 10px;
+`;
+
+export const RightWrapper = styled.div`
+    display: flex;
+    flex-direction: column;
+    align-items: end;
+`;
+
+export const QuestionRowMetadataSectionOne = styled.div`
+    display: flex;
+    align-items: center;
+`;
+
+export const LocationWrapper = styled.div`
+    display: flex;
+    align-items: center;
+    margin-right: 5px;
 `;

--- a/app/controllers/questions/list.js
+++ b/app/controllers/questions/list.js
@@ -160,9 +160,11 @@ export const listQuestions = async (params) => {
       Answers: {
         include: {
           Nps: true,
+          AnsweredBy: true,
         }
       },
       created_by: true,
+      Department: true,
     }
   });
 

--- a/app/routes/index.jsx
+++ b/app/routes/index.jsx
@@ -1,20 +1,89 @@
 import { json } from "@remix-run/node";
-// import ListQuestions from "~/components/ListQuestions";
+import { useFetcher, useLoaderData, useSearchParams } from "@remix-run/react";
+import ListQuestions from "~/components/ListQuestions";
 import Notifications from "~/components/Notifications";
-import { requireAuth } from "~/session.server";
+import { listDepartments } from "~/controllers/departments/list";
+import { listLocations } from "~/controllers/locations/list";
+import { listQuestions } from "~/controllers/questions/list";
+import { PAGE_QUESTIONS_LIMIT } from "~/utils/constants";
+import { getAuthenticatedUser, requireAuth } from "~/session.server";
 import * as Styled from '~/styles/Home.Styled';
+import dateRangeConversion from "../utils/dateRangeConversion";
+import { useEffect, useState } from "react";
 
 export const loader = async ({ request }) => {
   await requireAuth(request);
-  return json({});
+  const user = await getAuthenticatedUser(request);
+
+  const url = new URL(request.url);
+  
+  const order = url.searchParams.get("order");
+  const status = url.searchParams.get("status");
+  const department = Number.parseInt(url.searchParams.get("department"));
+  const location = url.searchParams.get("location");
+  const dateRange = dateRangeConversion(url.searchParams.get("dateRange"));
+  const page = url.searchParams.get("page") ?? 1;
+
+  const questions = await listQuestions({
+    user: user,
+    orderBy: order,
+    status: status,
+    department: isNaN(department) ? undefined : department,
+    location: location,
+    dateRange: dateRange,
+    offset: (page - 1) * PAGE_QUESTIONS_LIMIT,
+  });
+
+  const locations = await listLocations();
+  const departments = await listDepartments();
+
+  return json({
+    questions,
+    locations,
+    departments,
+  });
 }
 
 export default function Index() {
+  const { questions: initialQuestions } = useLoaderData();
+  const [questions, setQuestions] = useState(initialQuestions);
+
+  const fetcher = useFetcher();
+  const [shouldFetch, setShouldFetch] = useState(true);
+  const [page, setPage] = useState(2);
+  const [searchParams, ] = useSearchParams();
+
+  const onFetchMore = () => {
+    if(!shouldFetch) return;
+    fetcher.load(`/?index&${searchParams.toString()}&page=${page}`);
+  };
+
+  useEffect(() => {
+    if (fetcher.data && fetcher.data.questions && fetcher.data.questions.length === 0) {
+      setShouldFetch(false);
+      return;
+    }
+
+    if (fetcher.data && fetcher.data.questions && fetcher.data.questions.length > 0) {
+      setQuestions((prevQuestions) => [...prevQuestions, ...fetcher.data.questions]);
+      setPage((page) => page + 1);
+      setShouldFetch(true);
+    }
+
+  }, [fetcher.data]);
+
+  useEffect(() => {
+    setQuestions(initialQuestions);
+    setPage(2);
+    setShouldFetch(true);
+
+  }, [initialQuestions, searchParams]);
+
   return (
     <>
     <Notifications /> 
     <Styled.Container>
-      {/* <ListQuestions type="all" /> */}
+      <ListQuestions type="all" questions={questions} onFetchMore={onFetchMore} />
     </Styled.Container>
   </>
   );

--- a/app/styles/App.css
+++ b/app/styles/App.css
@@ -312,14 +312,14 @@ button.close:active {
 
 .reassign-question .modal-title {
   color: var(--color-dark-50);
-  font-family: 'NunitoSans Semibold', sans-serif;
+  font-family: 'Nunito', sans-serif;
   font-size: 16px;
   height: 19px;
   width: 173px; }
 
 .reassign-question .control-label label {
   color: var(--color-dark-50);
-  font-family: 'NunitoSans Semibold', sans-serif;
+  font-family: 'Nunito', sans-serif;
   font-size: 14px;
   height: 24px;
   letter-spacing: 0.6px;
@@ -473,7 +473,7 @@ label {
   
   .writeAnswer h4 {
     color: var(--color-dark-50);
-    font-family: NunitoSans Semibold, sans-serif;
+    font-family: Nunito, sans-serif;
     font-size: 16px;
     height: 19px;
     width: 311px; }

--- a/app/styles/NotFound.Styled.jsx
+++ b/app/styles/NotFound.Styled.jsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
-import { Link } from 'react-router-dom';
 import img from '~/images/header-background-dots-pattern.svg';
+import { Link } from '@remix-run/react';
 
 export const BackgroundDiv = styled.div`
     background-image: url(${img});

--- a/app/styles/sass/AnswerRow.scss
+++ b/app/styles/sass/AnswerRow.scss
@@ -44,7 +44,7 @@
 
 .writeAnswer h4 {
   color: var(--color-dark-50);
-  font-family: NunitoSans Semibold, sans-serif;
+  font-family: Nunito, sans-serif;
   font-size: 16px;
   height: 19px;
   width: 311px;

--- a/app/styles/sass/QuestionCard.scss
+++ b/app/styles/sass/QuestionCard.scss
@@ -44,7 +44,7 @@
 
 .reassign-question .modal-title {
   color: var(--color-dark-50);
-  font-family: 'NunitoSans Semibold', sans-serif;
+  font-family: 'Nunito', sans-serif;
   font-size: 16px;
   height: 19px;
   width: 173px;
@@ -52,7 +52,7 @@
 
 .reassign-question .control-label label {
   color: var(--color-dark-50);
-  font-family: 'NunitoSans Semibold', sans-serif;
+  font-family: 'Nunito', sans-serif;
   font-size: 14px;
   height: 24px;
   letter-spacing: 0.6px;

--- a/app/utils/constants.js
+++ b/app/utils/constants.js
@@ -79,6 +79,7 @@ export const DEPARTMENT_ACCESS_VALUE = 'department_id';
 export const LOCATION_LABEL = 'Location';
 export const DEFAULT_LOCATION = 'ALL';
 export const LOCATION_ACCESS_VALUE = DEFAULT_LOCATION_ACCESS_VALUE;
+export const DEFAULT_LOCATION_OPT = { name: 'All', code: DEFAULT_LOCATION };
 
 export const FILTER_BY_USER_TEXT = 'All questions';
 export const DEFAULT_FILTER_BY_USER = 'ALL_QUESTIONS';

--- a/app/utils/dateRangeConversion.js
+++ b/app/utils/dateRangeConversion.js
@@ -1,0 +1,42 @@
+const dateRangeConversion = (range) => {
+  let startDate;
+  let endDate;
+  switch(range) {
+    case "today":
+      startDate = new Date();
+      startDate.setHours(0,0,0,0);
+
+      return {
+        startDate: startDate,
+        endDate: new Date(),
+      }
+    case "this_week":
+      const curr = new Date();
+      const first = curr.getDate() - curr.getDay();
+      
+      startDate = new Date(curr.setDate(first));
+      startDate.setHours(0,0,0,0);
+
+      endDate = new Date();
+      
+      return {
+        startDate: startDate,
+        endDate: endDate,
+      }
+    case "this_month":
+      const now = new Date();
+
+      startDate = new Date(now.getFullYear(), now.getMonth(), 1);
+      endDate = new Date();
+
+      return {
+        startDate: startDate,
+        endDate: endDate,
+      }
+
+    default:
+      return undefined;
+  }
+}
+
+export default dateRangeConversion;

--- a/app/utils/questionUtils.js
+++ b/app/utils/questionUtils.js
@@ -9,7 +9,7 @@ import Button from '~/components/Atoms/Button';
 import AnswerAdminOptions from '~/components/AnswerAdminOptions';
 
 const renderDepartment = department =>
-  (department ? department.departmentName : DEPARTMENT_NOT_ASSIGNED);
+  (department ? department.name : DEPARTMENT_NOT_ASSIGNED);
 
 function shouldRenderAdminButtons(question, isAdmin) {
   return !question.Answer && isAdmin;
@@ -40,8 +40,8 @@ function renderAdminButtons(renderAdminBtnProps) {
 }
 
 function renderAnswer(renderAnswerProps) {
+
   const {
-    question: { Answer },
     isAdmin,
     currentUserEmail,
     onAnswerClick,
@@ -52,6 +52,12 @@ function renderAnswer(renderAnswerProps) {
     isQuestionModalOpen,
     isFromList,
   } = renderAnswerProps;
+
+  let Answer;
+  if (question.Answers.length > 0 ){
+    Answer = question.Answers[0];
+  }
+
   if (!Answer) {
     return null;
   }
@@ -59,6 +65,7 @@ function renderAnswer(renderAnswerProps) {
   if (Answer.numScores <= 1) {
     actionsEnabled = true;
   }
+
   return (
     <AnswerRow
       {...Answer}
@@ -67,6 +74,7 @@ function renderAnswer(renderAnswerProps) {
       isQuestionModalOpen={isQuestionModalOpen}
       questionId={question.question_id}
       isFromList={isFromList}
+      user={Answer.AnsweredBy}
     >
       { isAdmin && Answer.user.email === currentUserEmail && (
         <AnswerAdminOptions

--- a/app/utils/timeOperations.js
+++ b/app/utils/timeOperations.js
@@ -1,0 +1,14 @@
+import moment from 'moment';
+import { getFormattedDate } from './dateFormat';
+
+export function getTimeDiff(time) {
+  return moment(time).fromNow();
+}
+
+export function getDateData(time) {
+  const diff = moment.duration(moment().diff(time)).years();
+  if (diff > 0) {
+    return getFormattedDate(time);
+  }
+  return getTimeDiff(time);
+}

--- a/prisma/migrations/20221005205044_add_question_department_fk/migration.sql
+++ b/prisma/migrations/20221005205044_add_question_department_fk/migration.sql
@@ -1,0 +1,2 @@
+-- AddForeignKey
+ALTER TABLE `Questions` ADD CONSTRAINT `Questions_assigned_department_fkey` FOREIGN KEY (`assigned_department`) REFERENCES `Departments`(`department_id`) ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/migrations/20221006044929_add_answer_user_fk/migration.sql
+++ b/prisma/migrations/20221006044929_add_answer_user_fk/migration.sql
@@ -1,0 +1,2 @@
+-- AddForeignKey
+ALTER TABLE `Answers` ADD CONSTRAINT `Answers_answered_by_employee_id_fkey` FOREIGN KEY (`answered_by_employee_id`) REFERENCES `users`(`employee_id`) ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -25,6 +25,8 @@ model Answers {
   average_score           Float?    @default(0) @db.Float
   Nps                     Nps[]
   Question                Questions @relation(fields: [answered_question_id], references: [question_id])
+
+  AnsweredBy users @relation(fields: [answered_by_employee_id], references: [employee_id])
 }
 
 model CommentVote {
@@ -54,9 +56,10 @@ model Comments {
 }
 
 model Departments {
-  department_id Int     @id @default(autoincrement())
-  name          String  @db.VarChar(255)
-  is_active     Boolean @default(true)
+  department_id Int         @id @default(autoincrement())
+  name          String      @db.VarChar(255)
+  is_active     Boolean     @default(true)
+  Questions     Questions[]
 }
 
 model DraftAnswers {
@@ -133,6 +136,7 @@ model Questions {
   Sentiments                   Sentiments[]
   Votes                        Votes[]
   Answers                      Answers[]
+  Department                   Departments?   @relation(fields: [assigned_department], references: [department_id])
 
   @@index([assigned_to_employee_id], map: "assigned_to_employee_id_foreign_idx")
   @@index([created_by_employee_id], map: "created_by_employee_id_foreign_idx")
@@ -175,6 +179,7 @@ model users {
   EmployeesDepartments EmployeesDepartments[]
   Assigned             Questions[]            @relation("AssignedQuestion")
   Created              Questions[]            @relation("CreatedQuestion")
+  Answers              Answers[]
 
   @@index([email], map: "users_email")
 }


### PR DESCRIPTION
#### What does this PR do?
- Adds Remix hooks to list questions page to fetch questions with pagination and filters
- Adds some schema relations for usage, such as being able to retrieve the user from an answer.
- Some additional style tweaks to match what is current in wize-q-front (also including changes from [Alonso's PR](https://github.com/wizeline/wize-q-front/pull/767)

#### Where should the reviewer start?
- Pull branch
- Run migrations `npx prisma migrate dev`
- Run project and go to home

#### How should this be manually tested?
- Use multiple filters and order by to retrieve different results.

#### Any background context you want to provide?
- Things out of scope for this ticket are voting, pinning questions, and redirecting to question detail as these will be handled in other tickets.

#### What are the relevant tickets?
Closes #4 

#### Screenshots

https://user-images.githubusercontent.com/38927620/194410809-a5492554-bb6b-4ffe-9994-268d637a8548.mov


