### PR TITLE
feat(frontend): add pinning/unpinning handler

### DIFF
--- a/app/components/ListQuestions/ListQuestions.jsx
+++ b/app/components/ListQuestions/ListQuestions.jsx
@@ -2,10 +2,6 @@ import { useState } from 'react';
 
 import PropTypes from 'prop-types';
 import * as Styled from './ListQuestions.Styled';
-import {
-  FILTER_BY_USER_TEXT,
-  FILTER_BY_USER_TYPES,
-} from '~/utils/constants';
 import Slogan from '~/components/Slogan';
 import QuestionCard from '~/components/QuestionCard';
 import { useUser } from '~/utils/hooks/useUser';
@@ -20,6 +16,7 @@ const ListQuestions = ({
   onFetchMore,
 }) => {
   const profile = useUser();
+
   const [searchParams, setSearchParams] = useSearchParams();
 
   const [title, setTitle] = useState('Newest Questions');
@@ -76,6 +73,8 @@ const ListQuestions = ({
     const answeredBy = username ? `Answered by ${username}` : '';
     return answeredBy;
   };
+
+
 
   const renderQuestionsList = () => {
     if (questions.length === 0) { return null; }

--- a/app/components/Notifications/Notifications.jsx
+++ b/app/components/Notifications/Notifications.jsx
@@ -14,7 +14,13 @@ const Notifications = () => {
     }
     if (!data) return;
     
-    const { errors, success, warnings } = data;
+    const { error, errors, success, warnings } = data;
+
+    if (error) {
+      console.error(error.detail);
+      toast.error(error.message, DEFAULT_TOAST_CONFIG);
+    };
+
     if (errors && Array.isArray(errors)) {
       errors.forEach((error) => {
         console.error(error.detail);

--- a/app/components/QuestionRow/QuestionRow.jsx
+++ b/app/components/QuestionRow/QuestionRow.jsx
@@ -9,9 +9,11 @@ import pinIcon from '~/images/ic_pin.svg';
 import ConditionalLinkTo from '~/components/Atoms/ConditionalLinkTo';
 import QuestionResponderInfo from '~/components/QuestionResponderInfo';
 import QuestionMarkdown from '~/components/QuestionMarkdown';
-import { useLoaderData } from '@remix-run/react';
+import { useLoaderData, useSubmit } from '@remix-run/react';
 import { useUser } from '~/utils/hooks/useUser';
 import { getDateData } from '~/utils/timeOperations';
+import { useRef } from 'react';
+import { ACTIONS } from '~/utils/actions';
 
 
 const renderLocation = (location, locations) => {
@@ -21,6 +23,7 @@ const renderLocation = (location, locations) => {
 
   return locations.find(loc => loc.code === location).name;
 };
+
 
 const QuestionRow = (props) => {
   const {
@@ -32,43 +35,35 @@ const QuestionRow = (props) => {
     children,
     isFromList,
   } = props;
-  // const [isProcessingPinStateChange, setIsProcessingPinStateChange] = useState(false);
 
   const profile = useUser();
 
   const { locations } = useLoaderData();
   const isUpdated = false;
+  const pinForm = useRef();
+  const submit = useSubmit();
 
-  const clickPinOptionHandler = async (event) => {
-    // event.stopPropagation();
-    // if (isProcessingPinStateChange) return;
-    // setIsProcessingPinStateChange(true);
-    // const newPinStatusValue = question.is_pinned ? 'false' : 'true';
-    // try {
-    //   const response = await axios.post(`/api/questions/${question.question_id}/pin-status?pinStatus=${newPinStatusValue}`, {}, axiosConfig());
-    //   if (response.status !== 200) {
-    //     throw new Error('Unexpected status in the response when trying to update the pin status for the question');
-    //   }
-    //   if (response.data.is_pinned === undefined
-    //         || (response.data.is_pinned !== true && response.data.is_pinned !== false)) {
-    //     throw new Error('Unexpected value for is_pinned property in the response of the request');
-    //   }
-    //   // successAlertWithDuration(`The question has been ${response.data.is_pinned ? 'pinned' : 'unpinned'}`, 1000);
-    //   fetchQuestionsList();
-    // } catch (e) {
-    //   // dangerAlertWithDuration('Error trying to pin/unpin the question', 1000);
-    // }
-    // setIsProcessingPinStateChange(false);
-  };
+  const onPinChange = () => {
+    const newPinStatusValue = question.is_pinned ? 'false' : 'true';
+    const data = new FormData(pinForm.current);
+    data.set("action", ACTIONS.PINNIN);
+    data.set("questionId", question.question_id);
+    data.set("value", newPinStatusValue);
+
+    submit(
+      data,
+      { method: "post", action: "/?index"}
+    );
+  }
 
   const adminPinButton = (profile.is_admin && !question.is_pinned)
     ? (
-      <Styled.PinQuestionIconHolder onClick={clickPinOptionHandler} >
+      <Styled.PinQuestionIconHolder onClick={onPinChange} >
         <Styled.PinActionableIconHolder src={pinIcon} alt="Icon" />
         <Styled.PinTooltipMessage>Pin question to the top of the list</Styled.PinTooltipMessage>
       </Styled.PinQuestionIconHolder>)
     : (
-      <Styled.PinQuestionIconHolder onClick={clickPinOptionHandler} className="pin-tooltip" >
+      <Styled.PinQuestionIconHolder onClick={onPinChange} className="pin-tooltip" >
         <Styled.UnpinActionableIconHolder src={pinIcon} alt="Icon" />
         <Styled.PinTooltipMessage>Unpin question from top of the list</Styled.PinTooltipMessage>
       </Styled.PinQuestionIconHolder>);
@@ -171,6 +166,7 @@ QuestionRow.propTypes = {
   collapsed: PropTypes.bool,
   children: PropTypes.node,
   isFromList: PropTypes.bool,
+  onPinChange: PropTypes.func.isRequired,
 };
 
 QuestionRow.defaultProps = {

--- a/app/routes/index.jsx
+++ b/app/routes/index.jsx
@@ -10,6 +10,9 @@ import { getAuthenticatedUser, requireAuth } from "~/session.server";
 import * as Styled from '~/styles/Home.Styled';
 import dateRangeConversion from "../utils/dateRangeConversion";
 import { useEffect, useState } from "react";
+import { modifyPinStatus } from "~/controllers/questions/modifyPinStatus";
+import { ACTIONS } from "~/utils/actions";
+
 
 export const loader = async ({ request }) => {
   await requireAuth(request);
@@ -42,6 +45,21 @@ export const loader = async ({ request }) => {
     locations,
     departments,
   });
+}
+
+export const action = async ({ request }) => {
+  const formData = await request.formData();
+  const action = formData.get("action");
+  let response;
+
+  switch (action) {
+    case ACTIONS.PINNIN:
+      const questionId = parseInt(formData.get("questionId"));
+      const value = formData.get("value") !== 'false';
+      response = await modifyPinStatus(questionId, value);
+  }
+
+  return json(response);
 }
 
 export default function Index() {
@@ -79,11 +97,16 @@ export default function Index() {
 
   }, [initialQuestions, searchParams]);
 
+
   return (
     <>
     <Notifications /> 
     <Styled.Container>
-      <ListQuestions type="all" questions={questions} onFetchMore={onFetchMore} />
+      <ListQuestions
+        type="all"
+        questions={questions}
+        onFetchMore={onFetchMore}
+      />
     </Styled.Container>
   </>
   );

--- a/app/utils/actions.js
+++ b/app/utils/actions.js
@@ -1,0 +1,3 @@
+export const ACTIONS = {
+  PINNIN: "pin",
+};

--- a/tests/integration/controllers/questions/listQuestion.test.js
+++ b/tests/integration/controllers/questions/listQuestion.test.js
@@ -324,7 +324,7 @@ describe("listQuestions", () => {
       response = await listQuestions({
         dateRange: {
           startDate: "2022-02-15T00:00:00.000Z",
-          endDate: "2022-02-16T00:00:00.000Z"
+          endDate: "2022-02-16T24:00:00.000Z"
         },
       });
     });


### PR DESCRIPTION
#### What does this PR do?
- Adds action for calling pinning/unpinning questions
- Updates notification component to allow singular errors (error attribute instead of errors)
- Should be a good base for voting action #22 , and a example of how we can have multiple actions in one same page.
- Updates list question integration test that was for some unknown reason failing locally.

#### How should this be manually tested?
(List of steps to reproduce, corroborate or tests to run. Write this section clear enough so that external users can also follow it and test the fix.)
1. Go to questions list
2. Pin questions and verify a success message is shown
3. Verify question list is sorted
4. Refresh page and verify quesiton is on top, even with filters applied (that match)
5. Do the same for unpinning this question

#### What are the relevant tickets?
Closes #23 

#### Screenshots

https://user-images.githubusercontent.com/38927620/194957280-0284a75d-4a9a-47af-81a0-1c509ca6392c.mov

