### PR TITLE
feat(migration): Add like question action handler in the UI

### DIFF
--- a/app/components/CounterButton/CounterButton.Styled.jsx
+++ b/app/components/CounterButton/CounterButton.Styled.jsx
@@ -9,13 +9,22 @@ const handleColorType = (props) => {
   return '#31425a';
 };
 
+const setCursorType = (props) => {
+  if (props.processingFormSubmission) {
+    return 'not-allowed;';
+  }
+  else {
+    return 'pointer';
+  }
+};
+
 export const ContainerCounterButton = styled.button`
   align-items: center;
   background-color: transparent;
   border: none;
   border-radius: 3px;
   color: ${props => handleColorType(props)};
-  cursor: pointer;
+  cursor: ${props => setCursorType(props)};
   display: inline-flex;
   flex-direction: row;
   font-family: "Nunito", sans-serif;

--- a/app/components/CounterButton/CounterButton.Styled.jsx
+++ b/app/components/CounterButton/CounterButton.Styled.jsx
@@ -11,11 +11,9 @@ const handleColorType = (props) => {
 
 const setCursorType = (props) => {
   if (props.processingFormSubmission) {
-    return 'not-allowed;';
+    return 'not-allowed';
   }
-  else {
-    return 'pointer';
-  }
+  return 'pointer';
 };
 
 export const ContainerCounterButton = styled.button`

--- a/app/components/CounterButton/CounterButton.jsx
+++ b/app/components/CounterButton/CounterButton.jsx
@@ -2,12 +2,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import * as Styled from './CounterButton.Styled';
 
-const CounterButton = ({ icon, text, count, selected, onClick, notButton }) => {
+const CounterButton = ({ icon, text, count, selected, onClick, notButton, processingFormSubmission }) => {
   const validIcon = React.isValidElement(icon);
   return (<Styled.ContainerCounterButton
     onClick={onClick}
     selected={selected}
     notButton={notButton}
+    processingFormSubmission={processingFormSubmission}
   >
     {validIcon ? icon : <img src={icon} alt="Icon" />}
 
@@ -40,6 +41,7 @@ CounterButton.propTypes = {
   selected: PropTypes.bool,
   onClick: PropTypes.func,
   notButton: PropTypes.bool,
+  processingFormSubmission: PropTypes.bool,
 };
 
 export default CounterButton;

--- a/app/components/ListQuestions/ListQuestions.jsx
+++ b/app/components/ListQuestions/ListQuestions.jsx
@@ -80,7 +80,7 @@ const ListQuestions = ({
 
 
   const renderQuestionsList = () => {
-    const onLikeButtonClick = async (questionId) => {
+    const onLikeButtonClick = (questionId) => {
       if (transition.state !== 'idle') {
         return;
       }

--- a/app/components/QuestionCard/QuestionCard.jsx
+++ b/app/components/QuestionCard/QuestionCard.jsx
@@ -20,6 +20,7 @@ const QuestionCard = (props) => {
     onVoteClick,
     searchTerm,
     fetchQuestionsList,
+    processingFormSubmission,
   } = props;
 
 
@@ -50,6 +51,7 @@ const QuestionCard = (props) => {
           text={addS('Like', question.num_votes)}
           count={question.num_votes}
           onClick={() => onVoteClick(question)}
+          processingFormSubmission={processingFormSubmission}
         />
         <CounterButton
           icon={commentIcon}
@@ -111,6 +113,7 @@ QuestionCard.propTypes = {
   onVoteClick: PropTypes.func.isRequired,
   currentUserEmail: PropTypes.string,
   searchTerm: PropTypes.string,
+  processingFormSubmission: PropTypes.bool,
 };
 
 QuestionCard.defaultProps = {

--- a/app/components/QuestionDetail/QuestionDetail.jsx
+++ b/app/components/QuestionDetail/QuestionDetail.jsx
@@ -50,7 +50,7 @@ function QuestionDetails(props) {
   };
 
   const renderQuestionButtons = () => {
-    const onLikeButtonClick = async () => {
+    const onLikeButtonClick = () => {
       if (transition.state !== 'idle') {
         return;
       }

--- a/app/components/QuestionDetail/QuestionDetail.jsx
+++ b/app/components/QuestionDetail/QuestionDetail.jsx
@@ -1,4 +1,5 @@
-import {useState } from 'react';
+import {useState, useRef } from 'react';
+import { useSubmit, useTransition } from '@remix-run/react';
 import { useParams } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import likeIcon from '~/images/ic_like.svg';
@@ -22,9 +23,12 @@ import QuestionRow from '~/components/QuestionRow';
 import Loader from '~/components/Loader';
 import logomark from '~/images/logomark_small.png';
 import { useUser } from '~/utils/hooks/useUser';
+import { ACTIONS } from '~/utils/actions';
 
 function QuestionDetails(props) {
-
+  const submit = useSubmit();
+  const transition = useTransition();
+  const voteQuestionForm = useRef();
   const profile = useUser();
   const isAdmin = profile.is_admin;
   const currentUserEmail = profile.email;
@@ -46,6 +50,17 @@ function QuestionDetails(props) {
   };
 
   const renderQuestionButtons = () => {
+    const onLikeButtonClick = async () => {
+      if (transition.state !== 'idle') {
+        return;
+      }
+      const data = new FormData(voteQuestionForm.current);
+      data.set("action", ACTIONS.VOTE_QUESTION);
+      data.set("questionId", question.question_id);
+      data.set("user", JSON.stringify(profile));
+      submit(data, { method: 'post', action: `/questions/${question.question_id}` });
+    };
+
     const icon = !question.hasVoted ? likeIcon : likeIconVoted;
     return (
       <Styled.CounterButtonsWrapper isAdmin={isAdmin} hasAnswer={question.Answer}>
@@ -54,7 +69,8 @@ function QuestionDetails(props) {
           icon={icon}
           text={addS('Like', question.num_votes)}
           count={question.num_votes}
-          onClick={() => {}}
+          processingFormSubmission={transition.state !== 'idle'}
+          onClick={onLikeButtonClick}
         />
         <CounterButton
           notButton

--- a/app/routes/index.jsx
+++ b/app/routes/index.jsx
@@ -61,11 +61,7 @@ export const action = async ({ request }) => {
     case ACTIONS.VOTE_QUESTION:
       const voteQuestionId = parseInt(formData.get("questionId"));
       const voteQuestionUser = JSON.parse(formData.get("user"));
-      if (voteQuestionUser.id !== undefined && voteQuestionUser.id !== null && voteQuestionUser.id.length > 0) {
-        response = await voteQuestion(voteQuestionId, voteQuestionUser);
-      } else {
-        response = null;
-      }
+      response = await voteQuestion(voteQuestionId, voteQuestionUser);
   }
 
   return json(response);

--- a/app/routes/index.jsx
+++ b/app/routes/index.jsx
@@ -11,6 +11,7 @@ import * as Styled from '~/styles/Home.Styled';
 import dateRangeConversion from "../utils/dateRangeConversion";
 import { useEffect, useState } from "react";
 import { modifyPinStatus } from "~/controllers/questions/modifyPinStatus";
+import { voteQuestion } from "~/controllers/questionVotes/voteQuestion";
 import { ACTIONS } from "~/utils/actions";
 
 
@@ -57,6 +58,14 @@ export const action = async ({ request }) => {
       const questionId = parseInt(formData.get("questionId"));
       const value = formData.get("value") !== 'false';
       response = await modifyPinStatus(questionId, value);
+    case ACTIONS.VOTE_QUESTION:
+      const voteQuestionId = parseInt(formData.get("questionId"));
+      const voteQuestionUser = JSON.parse(formData.get("user"));
+      if (voteQuestionUser.id !== undefined && voteQuestionUser.id !== null && voteQuestionUser.id.length > 0) {
+        response = await voteQuestion(voteQuestionId, voteQuestionUser);
+      } else {
+        response = null;
+      }
   }
 
   return json(response);

--- a/app/routes/questions/$questionId.jsx
+++ b/app/routes/questions/$questionId.jsx
@@ -10,6 +10,7 @@ import { requireAuth, getAuthenticatedUser } from "~/session.server";
 import { getQuestionById } from "~/controllers/questions/getQuestionById";
 import { listLocations } from "~/controllers/locations/list";
 import { modifyPinStatus } from "~/controllers/questions/modifyPinStatus";
+import { voteQuestion } from "~/controllers/questionVotes/voteQuestion";
 import { ACTIONS } from "~/utils/actions";
 import { json } from "@remix-run/node";
 
@@ -37,6 +38,10 @@ export const action = async ({ request }) => {
       const questionId = parseInt(formData.get("questionId"));
       const value = formData.get("value") !== 'false';
       response = await modifyPinStatus(questionId, value);
+    case ACTIONS.VOTE_QUESTION:
+      const voteQuestionId = parseInt(formData.get("questionId"));
+      const voteQuestionUser = JSON.parse(formData.get("user"));
+      response = await voteQuestion(voteQuestionId, voteQuestionUser);
   }
 
   return json(response);

--- a/app/utils/actions.js
+++ b/app/utils/actions.js
@@ -1,3 +1,4 @@
 export const ACTIONS = {
   PINNIN: "pin",
+  VOTE_QUESTION: 'vote_question',
 };


### PR DESCRIPTION
#### What does this PR do?
It adds the ability to like a question both in the question list index page and in the question detail page, debouncing multiple clicks in rapid succession using the useState hook available for Remix.


https://user-images.githubusercontent.com/104774638/196557306-842e27d3-4354-439a-80f7-bdc0c0f96c9b.mov


#### Where should the reviewer start?
- app/components/ListQuestions/ListQuestions.jsx
- app/routes/index.jsx
- app/components/QuestionDetail/QuestionDetail.jsx
- app/routes/questions/$questionId.jsx

#### How should this be manually tested?
1. Apply some filtering criteria in the list of questions that has some results
2. Vote one of the filtered questions
3. The search parameters should be kept after submitting the like action
4. Open the details of a question and verify that we can like the question there as well, with a 'not-allowed' cursor when hovering over the like button when there's a like submission being processed.

#### What are the relevant tickets?
(Link to issues, related PR, JIRA issues, etc.)
Closes #35