### PR TITLE
feat: add @updatedAt prisma attribute to updatedAt columns. 

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -20,7 +20,7 @@ model Answers {
   answered_by_employee_id Int
   answered_question_id    Int
   createdAt               DateTime  @default(now()) @db.DateTime(0)
-  updatedAt               DateTime  @default(now()) @db.DateTime(0)
+  updatedAt               DateTime  @default(now()) @db.DateTime(0) @updatedAt
   num_scores              Int?      @default(0)
   average_score           Float?    @default(0) @db.Float
   Nps                     Nps[]
@@ -50,7 +50,7 @@ model Comments {
   sessionHash String?       @db.VarChar(255)
   userName    String?       @db.VarChar(255)
   userEmail   String?       @db.VarChar(255)
-  updatedAt   DateTime?     @db.DateTime(0)
+  updatedAt   DateTime?     @db.DateTime(0) @updatedAt
   approvedBy  Int?
   Approver    users?        @relation("Comments_approvedByTousers", fields: [approvedBy], references: [employee_id], onDelete: NoAction, onUpdate: NoAction, map: "Comments_approved_by_employeeId")
   User        users?        @relation("Comments_userEmailTousers", fields: [userEmail], references: [email], onDelete: NoAction, onUpdate: NoAction, map: "Comments_created_by_employeeId")
@@ -126,7 +126,7 @@ model Questions {
   user_hash                    String         @default("") @db.VarChar(255)
   is_anonymous                 Boolean
   createdAt                    DateTime       @default(now()) @db.DateTime(0)
-  updatedAt                    DateTime       @default(now()) @db.DateTime(0)
+  updatedAt                    DateTime       @default(now()) @db.DateTime(0) @updatedAt
   location                     String?        @default("ALL") @db.VarChar(255)
   last_email_notification_date DateTime?      @db.DateTime(0)
   assigned_department          Int?

--- a/tests/integration/controllers/answers/updateAnswer.test.js
+++ b/tests/integration/controllers/answers/updateAnswer.test.js
@@ -1,4 +1,5 @@
 import { updateAnswer } from '~/controllers/answers/update';
+import {getFormattedDate } from '~/utils/dateFormat';
 
 describe('updateAnswer', () => {
   it('should validate fields', async () => {
@@ -27,4 +28,16 @@ describe('updateAnswer', () => {
     };
     await expect(updateAnswer(payload)).rejects.toThrowError();
   });
+
+  it('return the current date in the updatedAt field when updating an answer',async () => {
+    const payload = {
+      answer_id: 1,
+      answer_text: 'New answer text',
+    };
+
+    const response = await updateAnswer(payload);
+    expect(response).toBeDefined();
+    expect(response.success).toBeDefined();
+    expect(getFormattedDate(response.updatedAnswer.updatedAt)).toEqual(getFormattedDate(new Date()));
+  })
 });

--- a/tests/integration/controllers/questions/modifyPinStatus.test.js
+++ b/tests/integration/controllers/questions/modifyPinStatus.test.js
@@ -7,6 +7,7 @@ import {
   QUESTION_NOT_FOUND_ERROR_MESSAGE,
 } from "~/utils/constants";
 import { db } from "~/utils/db.server";
+import {getFormattedDate } from '~/utils/dateFormat';
 
 describe("questions controller", () => {
   describe("Modify pin status of a question (modifyPinStatus)", () => {
@@ -82,5 +83,16 @@ describe("questions controller", () => {
       expect(dbUpdateSpy).toHaveBeenCalledTimes(2);
     });
     
+    it('return the current date in the updatedAt field when updating a question', async () => {
+      const response = await modifyPinStatus(1, true);
+      expect(response.error).toBeUndefined();
+      expect(response.success).toBeDefined();
+      expect(response.question).toBeDefined();
+      expect(response.success).toBe('The question has been pinned');
+      expect(response.question.is_pinned).toBeDefined();
+      expect(response.question.is_pinned).toBe(true);
+      expect(getFormattedDate(response.question.updatedAt)).toEqual(getFormattedDate(new Date()));
+    });
+
   });
 });


### PR DESCRIPTION
#### What does this PR do?
- Add @updateAt prisma attribute on the updateAt columns 
- Tables:
     - Questions
     - Comments
     - Answers

#### Where should the reviewer start?
- prisma/schema.prisma
- tests/integration/controllers/answers/updateAnswer.test.js
- tests/integration/controllers/questions/modifyPinStatus.test.js

#### How should this be manually tested?
1. run the command `nxp prisma db pull`  to update your db according to your schema. 
[Questions]
<img width="906" alt="Screen Shot 2022-10-20 at 15 52 26" src="https://user-images.githubusercontent.com/97203617/197055703-994e6380-7fef-4c97-8bf2-837bc0ca73bc.png">
[Comments]
<img width="642" alt="Screen Shot 2022-10-20 at 15 53 04" src="https://user-images.githubusercontent.com/97203617/197055797-81060321-7563-47e9-8036-97ea96ebb7b9.png">
[Answer]
<img width="912" alt="Screen Shot 2022-10-20 at 15 53 46" src="https://user-images.githubusercontent.com/97203617/197055939-63cb6970-744e-402c-af46-956917a96f92.png">

2. run the test `npm run test:integration`
3. Verify that all tests have passed.

#### Any background context you want to provide?
Ticket raised from the following discussion [feat(migration): add comments list controller](https://github.com/wizeline/wize-q-remix/pull/40#pullrequestreview-1148346757)  

#### What are the relevant tickets?
Closes #45 

#### Screenshots

<img width="823" alt="Screen Shot 2022-10-20 at 15 59 37" src="https://user-images.githubusercontent.com/97203617/197057043-08cdac96-f3d5-4f84-a800-372329747ea9.png">
