### PR TITLE
feat(migration): Add delete comment controller with integration tests

### DIFF
--- a/app/controllers/comments/create.js
+++ b/app/controllers/comments/create.js
@@ -1,4 +1,7 @@
 import { DEFAULT_ERROR_MESSAGE } from "~/utils/backend/constants";
+import {
+  INVALID_PARAMS_FOR_OPERATION_ERROR_MESSAGE,
+} from "~/utils/constants";
 import generateSessionIdHash from "~/utils/backend/crypto";
 import { createCommentSchema } from "~/utils/backend/validators/comment"
 import { db } from "~/utils/db.server";
@@ -15,6 +18,14 @@ export const createComment = async (data) => {
     }
   }
 
+  if (!value.isAnonymous && !value.user.userEmail) {
+    return {
+      error: {
+        message: INVALID_PARAMS_FOR_OPERATION_ERROR_MESSAGE,
+        detail: "The comment is not anonymous but no user email was provided in the user object",
+      }
+    }
+  }
 
   const commentData = {
     Questions: {
@@ -25,7 +36,7 @@ export const createComment = async (data) => {
     comment: value.comment,
   };
 
-  if (value.user.userEmail) {
+  if (!value.isAnonymous) {
     commentData.User = {
       connect: {
         email: value.user.userEmail,

--- a/app/controllers/comments/create.js
+++ b/app/controllers/comments/create.js
@@ -15,15 +15,26 @@ export const createComment = async (data) => {
     }
   }
 
-  const created = await db.Comments.create({
-    data: {
-      Questions: {
-        connect: {
-          question_id: value.questionId,
-        },
+
+  const commentData = {
+    Questions: {
+      connect: {
+        question_id: value.questionId,
       },
-      comment: value.comment,
+    },
+    comment: value.comment,
+  };
+
+  if (value.user.userEmail) {
+    commentData.User = {
+      connect: {
+        email: value.user.userEmail,
+      }
     }
+  }
+
+  const created = await db.Comments.create({
+    data: commentData
   });
 
   let commentResponse = created;

--- a/app/controllers/comments/delete.js
+++ b/app/controllers/comments/delete.js
@@ -1,0 +1,88 @@
+import { db } from "~/utils/db.server";
+import generateSessionIdHash from "~/utils/backend/crypto";
+import { generateMinMaxDates } from "~/utils/backend/comments";
+import { deleteCommentSchema } from "~/utils/backend/validators/comments";
+import { DEFAULT_ERROR_MESSAGE } from "~/utils/backend/constants";
+import {
+  INVALID_PARAMS_FOR_OPERATION_ERROR_MESSAGE,
+  DELETE_COMMENT_ERROR_MESSAGE,
+} from "~/utils/constants";
+
+export const deleteComment = async (body) => {
+  const { error, value } = deleteCommentSchema.validate(body);
+
+  if (error) {
+    return {
+      errors: [
+        {
+          message: INVALID_PARAMS_FOR_OPERATION_ERROR_MESSAGE,
+          detail: error,
+        },
+      ],
+    };
+  }
+
+  const { commentId: id, accessToken, userEmail } = value;
+
+  const sessionHash = generateSessionIdHash(accessToken, id);
+  const { minDate, maxDate } = generateMinMaxDates();
+
+  const deleteCommentResponse = await db.Comments.deleteMany({
+    where: {
+      id,
+      OR: [
+        {
+          userEmail,
+        },
+        {
+          AND: [
+            {
+              sessionHash,
+            },
+            {
+              createdAt: { lte: new Date(maxDate) },
+            },
+            {
+              createdAt: { gte: new Date(minDate) },
+            },
+          ],
+        },
+      ],
+    },
+  });
+
+  if (
+    deleteCommentResponse.count === undefined ||
+    typeof deleteCommentResponse.count !== "number"
+  ) {
+    return {
+      error: {
+        message: DEFAULT_ERROR_MESSAGE,
+        detail: "Something went wrong trying to delete the comment",
+      },
+    };
+  }
+
+  if (deleteCommentResponse.count === 0) {
+    return {
+      error: {
+        message: DELETE_COMMENT_ERROR_MESSAGE,
+        detail:
+          "Comment not found or user does not have deletion rights over the comment",
+      },
+    };
+  }
+  if (deleteCommentResponse.count === 1) {
+    return {
+      success: true,
+      response: "Comment was deleted successfully",
+    };
+  }
+
+  return {
+    error: {
+      message: DELETE_COMMENT_ERROR_MESSAGE,
+      detail: `Multiple comments were deleted, which should not have happened, number of affected comments: ${deleteCommentResponse.count}`,
+    },
+  };
+};

--- a/app/controllers/comments/delete.js
+++ b/app/controllers/comments/delete.js
@@ -68,7 +68,7 @@ export const deleteComment = async (body) => {
       error: {
         message: DELETE_COMMENT_ERROR_MESSAGE,
         detail:
-          "Comment not found or user does not have deletion rights over the comment",
+          `Comment not found or user does not have deletion rights over the comment. Comment id: ${id}`,
       },
     };
   }

--- a/app/utils/backend/validators/comments.js
+++ b/app/utils/backend/validators/comments.js
@@ -22,3 +22,9 @@ export const updateCommentSchema = Joi.object().keys({
   userEmail: EMAIL_VALIDATION,
 });
 
+export const deleteCommentSchema = Joi.object().keys({
+  commentId: JOI_ID_VALIDATION,
+  accessToken: Joi.string().required(),
+  userEmail: EMAIL_VALIDATION,
+});
+

--- a/app/utils/constants.js
+++ b/app/utils/constants.js
@@ -326,3 +326,4 @@ export const INVALID_PARAMS_FOR_OPERATION_ERROR_MESSAGE = 'The provided paramete
 export const QUESTION_NOT_FOUND_ERROR_MESSAGE = 'The question with the id provided could not be found';
 export const INVALIDATE_VOTE_ERROR_MESSAGE = 'Error trying to invalidate the vote in the question';
 export const UPDATE_COMMENT_ERROR_MESSAGE = 'Error trying to update the comment';
+export const DELETE_COMMENT_ERROR_MESSAGE = 'Error trying to delete the comment';

--- a/tests/integration/controllers/comments/createComment.test.js
+++ b/tests/integration/controllers/comments/createComment.test.js
@@ -30,8 +30,8 @@ describe('createComment', () => {
       questionId: 2,
       user: {
         accessToken: randomAccessToken(),
-        userEmail: "testuser@gmail.com",
-        userName: "John Smith Doe",
+        userEmail: "john.doe@wizeline.com",
+        userName: "John Doe",
       },
     };
 

--- a/tests/integration/controllers/comments/deleteComment.test.js
+++ b/tests/integration/controllers/comments/deleteComment.test.js
@@ -1,0 +1,121 @@
+import { createComment } from "~/controllers/comments/create";
+import { deleteComment } from "~/controllers/comments/delete";
+import { randomAccessToken } from "./../../../utils";
+
+import { db } from "~/utils/db.server";
+
+describe('delete comment controller', () => {
+    const dbDeleteManyCommentSpy = jest.spyOn(db.Comments, "deleteMany");
+
+    it('returns an error when accessToken is not provided', async () => {
+        const deleteCommentBody = {
+            commentId: 1001,
+            accessToken: null,
+            userEmail: "miguel.cardona@wizeline.com",
+        };
+
+        const deleteCommentResponse = await deleteComment(deleteCommentBody);
+        expect(deleteCommentResponse).toBeDefined();
+        expect(deleteCommentResponse.errors).toBeDefined();
+        expect(deleteCommentResponse.errors[0].message).toBe('The provided parameters for the operation are not valid');
+        expect(deleteCommentResponse.errors[0].detail.toString()).toContain('accessToken');
+        expect(dbDeleteManyCommentSpy).toHaveBeenCalledTimes(0);
+    });
+
+    it('returns an error when provided user email does not match with the comment author', async () => {
+        const deleteCommentBody = {
+          commentId: 11,
+          accessToken: randomAccessToken(),
+          userEmail: "not.matching@wizeline.com",
+        };
+
+        const deleteCommentResponse = await deleteComment(deleteCommentBody);
+        expect(deleteCommentResponse).toBeDefined();
+        expect(deleteCommentResponse.error).toBeDefined();
+        expect(deleteCommentResponse.error.message).toBe('Error trying to delete the comment');
+        expect(deleteCommentResponse.error.detail).toBe('Comment not found or user does not have deletion rights over the comment');
+        expect(dbDeleteManyCommentSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns an error when session hash matches but createdAt is out of range', async () => {
+        const deleteCommentBody = {
+          commentId: 12,
+          accessToken: '8b1a5ca556d49fc46c169b2c94a058065d566f01bb208519cffd2d7419f4ff8cb4d63a060019e86354708c55766a60a2449edff151bb34681d4012699ebc3b22',
+        };
+
+        const deleteCommentResponse = await deleteComment(deleteCommentBody);
+        expect(deleteCommentResponse).toBeDefined();
+        expect(deleteCommentResponse.error).toBeDefined();
+        expect(deleteCommentResponse.error.message).toBe('Error trying to delete the comment');
+        expect(deleteCommentResponse.error.detail).toBe('Comment not found or user does not have deletion rights over the comment');
+        expect(dbDeleteManyCommentSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('deletes the comment when author email matches', async () => {
+
+        const createCommentBody = {
+            comment: 'Test delete comment controller',
+            questionId: 10,
+            user: {
+              accessToken: randomAccessToken(),
+              userEmail: "eduardo.garibo@wizeline.com",
+              userName: "Eduardo Mendoza Garibo",
+            },
+        };
+
+        const deleteCommentBody = {
+          commentId: null,
+          accessToken: randomAccessToken(),
+          userEmail: "eduardo.garibo@wizeline.com",
+        };
+
+        const createCommentResponse = await createComment(createCommentBody);
+
+        expect(createCommentResponse.success).toBeDefined();
+        expect(createCommentResponse.comment.id).toBeDefined();
+        expect(typeof createCommentResponse.comment.id).toBe('number');
+
+
+        deleteCommentBody.commentId = createCommentResponse.comment.id;
+
+        const deleteCommentResponse = await deleteComment(deleteCommentBody);
+        expect(deleteCommentResponse).toBeDefined();
+        expect(deleteCommentResponse.success).toBe(true);
+        expect(deleteCommentResponse.response).toBeDefined();
+        expect(deleteCommentResponse.response).toBe('Comment was deleted successfully');
+        expect(dbDeleteManyCommentSpy).toHaveBeenCalledTimes(3);
+    });
+
+    it('deletes the comment when author session hash matches', async () => {
+
+        const createCommentBody = {
+            comment: 'Test delete comment controller',
+            questionId: 10,
+            user: {
+              accessToken: '8b1a5ca556d49fc46c169b2c94a058065d566f01bb208519cffd2d7419f4ff8cb4d63a060019e86354708c55766a60a2449edff151bb34681d4012699ebc3j65',
+            },
+            isAnonymous: true,
+        };
+
+        const deleteCommentBody = {
+          commentId: null,
+          accessToken: '8b1a5ca556d49fc46c169b2c94a058065d566f01bb208519cffd2d7419f4ff8cb4d63a060019e86354708c55766a60a2449edff151bb34681d4012699ebc3j65'
+        };
+
+        const createCommentResponse = await createComment(createCommentBody);
+
+        expect(createCommentResponse.success).toBeDefined();
+        expect(createCommentResponse.comment.id).toBeDefined();
+        expect(typeof createCommentResponse.comment.id).toBe('number');
+
+
+        deleteCommentBody.commentId = createCommentResponse.comment.id;
+
+        const deleteCommentResponse = await deleteComment(deleteCommentBody);
+        expect(deleteCommentResponse).toBeDefined();
+        expect(deleteCommentResponse.success).toBe(true);
+        expect(deleteCommentResponse.response).toBeDefined();
+        expect(deleteCommentResponse.response).toBe('Comment was deleted successfully');
+        expect(dbDeleteManyCommentSpy).toHaveBeenCalledTimes(4);
+    });
+});

--- a/tests/integration/controllers/comments/deleteComment.test.js
+++ b/tests/integration/controllers/comments/deleteComment.test.js
@@ -7,6 +7,10 @@ import { db } from "~/utils/db.server";
 describe('delete comment controller', () => {
     const dbDeleteManyCommentSpy = jest.spyOn(db.Comments, "deleteMany");
 
+    afterEach(() => {    
+      dbDeleteManyCommentSpy.mockClear();
+    });
+
     it('returns an error when accessToken is not provided', async () => {
         const deleteCommentBody = {
             commentId: 1001,
@@ -33,7 +37,7 @@ describe('delete comment controller', () => {
         expect(deleteCommentResponse).toBeDefined();
         expect(deleteCommentResponse.error).toBeDefined();
         expect(deleteCommentResponse.error.message).toBe('Error trying to delete the comment');
-        expect(deleteCommentResponse.error.detail).toBe('Comment not found or user does not have deletion rights over the comment');
+        expect(deleteCommentResponse.error.detail).toContain('Comment not found or user does not have deletion rights over the comment');
         expect(dbDeleteManyCommentSpy).toHaveBeenCalledTimes(1);
     });
 
@@ -47,8 +51,8 @@ describe('delete comment controller', () => {
         expect(deleteCommentResponse).toBeDefined();
         expect(deleteCommentResponse.error).toBeDefined();
         expect(deleteCommentResponse.error.message).toBe('Error trying to delete the comment');
-        expect(deleteCommentResponse.error.detail).toBe('Comment not found or user does not have deletion rights over the comment');
-        expect(dbDeleteManyCommentSpy).toHaveBeenCalledTimes(2);
+        expect(deleteCommentResponse.error.detail).toContain('Comment not found or user does not have deletion rights over the comment');
+        expect(dbDeleteManyCommentSpy).toHaveBeenCalledTimes(1);
     });
 
     it('deletes the comment when author email matches', async () => {
@@ -83,7 +87,7 @@ describe('delete comment controller', () => {
         expect(deleteCommentResponse.success).toBe(true);
         expect(deleteCommentResponse.response).toBeDefined();
         expect(deleteCommentResponse.response).toBe('Comment was deleted successfully');
-        expect(dbDeleteManyCommentSpy).toHaveBeenCalledTimes(3);
+        expect(dbDeleteManyCommentSpy).toHaveBeenCalledTimes(1);
     });
 
     it('deletes the comment when author session hash matches', async () => {
@@ -116,6 +120,6 @@ describe('delete comment controller', () => {
         expect(deleteCommentResponse.success).toBe(true);
         expect(deleteCommentResponse.response).toBeDefined();
         expect(deleteCommentResponse.response).toBe('Comment was deleted successfully');
-        expect(dbDeleteManyCommentSpy).toHaveBeenCalledTimes(4);
+        expect(dbDeleteManyCommentSpy).toHaveBeenCalledTimes(1);
     });
 });

--- a/tests/integration/controllers/comments/updateComment.test.js
+++ b/tests/integration/controllers/comments/updateComment.test.js
@@ -4,7 +4,7 @@ import { randomAccessToken } from "./../../../utils";
 import { db } from "~/utils/db.server";
 
 describe('update comment controller', () => {
-    const dbUpdateManyCommentSpy = jest.spyOn(db.Comments, "updateMany");
+  const dbUpdateManyCommentSpy = jest.spyOn(db.Comments, "updateMany");
 
     it('returns an error when provided invalid comment content', async () => {
         const updateCommentBody = {


### PR DESCRIPTION
#### What does this PR do?
It adds the delete comment controller and adds the userEmail field when creating a comment if said 'userEmail' property is available in the 'user' object inside the payload for creating a new comment. 

#### Where should the reviewer start?
- app/controllers/comments/delete.js
- tests/integration/controllers/comments/deleteComment.test.js
- app/controllers/comments/create.js

#### How should this be manually tested?
Tested by the integration tests included.

#### What are the relevant tickets?
(Link to issues, related PR, JIRA issues, etc.)
Closes #43 