### PR TITLE
feat: (migration)Add controller to approve a comment as an answer

### DIFF
--- a/app/controllers/comments/approvedBy.js
+++ b/app/controllers/comments/approvedBy.js
@@ -1,7 +1,7 @@
 import { db } from "~/utils/db.server";
 import { approvedByCommentSchema } from "~/utils/backend/validators/comments";
 import { INVALID_PARAMS_FOR_OPERATION_ERROR_MESSAGE } from "~/utils/constants";
-import { COMMENT_AS_AN_ANSWER, DEFAULT_ERROR_MESSAGE, UPDATE_COMMENT_ERROR_MESSAGE} from '~/utils/backend/constants';
+import { COMMENT_AS_AN_ANSWER, DEFAULT_ERROR_MESSAGE} from '~/utils/backend/constants';
 import { isEmptyObject } from '~/utils/backend/objectUtils';
 
 export const approvedByComment = async(params) => {

--- a/app/controllers/comments/approvedBy.js
+++ b/app/controllers/comments/approvedBy.js
@@ -2,7 +2,7 @@ import { db } from "~/utils/db.server";
 import { approvedByCommentSchema } from "~/utils/backend/validators/comments";
 import { INVALID_PARAMS_FOR_OPERATION_ERROR_MESSAGE } from "~/utils/constants";
 import { COMMENT_AS_AN_ANSWER, DEFAULT_ERROR_MESSAGE, UPDATE_COMMENT_ERROR_MESSAGE} from '~/utils/backend/constants';
-import { isEmpty } from '~/utils/backend/objectUtils';
+import { isEmptyObject } from '~/utils/backend/objectUtils';
 
 export const approvedByComment = async(params) => {
     const { error, value } = approvedByCommentSchema.validate(params);
@@ -50,7 +50,7 @@ export const approvedByComment = async(params) => {
         data: {approvedBy: checked ? employeeId: null 
     }});
 
-    if(isEmpty(commentUpdated)){
+    if(isEmptyObject(commentUpdated)){
         return {
             error: {
               message: DEFAULT_ERROR_MESSAGE,

--- a/app/controllers/comments/approvedBy.js
+++ b/app/controllers/comments/approvedBy.js
@@ -1,0 +1,66 @@
+import { db } from "~/utils/db.server";
+import { approvedByCommentSchema } from "~/utils/backend/validators/comments";
+import { INVALID_PARAMS_FOR_OPERATION_ERROR_MESSAGE } from "~/utils/constants";
+import { COMMENT_AS_AN_ANSWER, DEFAULT_ERROR_MESSAGE, UPDATE_COMMENT_ERROR_MESSAGE} from '~/utils/backend/constants';
+import { isEmpty } from '~/utils/backend/objectUtils';
+
+export const approvedByComment = async(params) => {
+    const { error, value } = approvedByCommentSchema.validate(params);
+
+    if (error) {
+        return {
+          errors: [
+            {
+              message: INVALID_PARAMS_FOR_OPERATION_ERROR_MESSAGE,
+              detail: error,
+            },
+          ],
+        };
+    }
+
+    const {questionId, commentId, employeeId, checked} = value;
+    const fetchComments = await db.Comments.findMany({where: {
+        AND:[{
+            questionId: questionId
+        },{
+            id:{
+                not: commentId
+            }
+        },{
+            approvedBy:{
+                not: null
+            }
+        }]
+    }});
+    
+    const hasAnswer =  fetchComments.length > 0;
+    if(hasAnswer){
+        return{
+            errors: [
+                {
+                    message: COMMENT_AS_AN_ANSWER,
+                    detail: COMMENT_AS_AN_ANSWER
+                }
+            ]
+        }
+    }
+
+    const commentUpdated = await db.Comments.update({ 
+        where: {id: commentId}, 
+        data: {approvedBy: checked ? employeeId: null 
+    }});
+
+    if(isEmpty(commentUpdated)){
+        return {
+            error: {
+              message: DEFAULT_ERROR_MESSAGE,
+              detail: "Something went wrong trying to update the comment",
+            },
+          };
+    }
+
+    return {
+        success: true,
+        response: `Comment ${checked? 'marked' : 'unmarked'} as an answer successfully`,
+    };
+}

--- a/app/utils/actions.js
+++ b/app/utils/actions.js
@@ -4,4 +4,5 @@ export const ACTIONS = {
   CREATE_QUESTION_ANSWER: 'create_question_answer',
   UPDATE_QUESTION_ANSWER: 'edit_question_answer',
   DELETE_ANSWER: 'delete_answer',
+  APPROVED_COMMENT: 'approved_comment'
 };

--- a/app/utils/backend/constants.js
+++ b/app/utils/backend/constants.js
@@ -17,4 +17,5 @@ module.exports = {
   MIN_NET_PROMOTER_SCORE: 1,
   MAX_NET_PROMOTER_SCORE: 4,
   DEFAULT_ERROR_MESSAGE: "An unknown error has occurred with your request.",
+  COMMENT_AS_AN_ANSWER: "This question already has a comment as answer"
 };

--- a/app/utils/backend/objectUtils.js
+++ b/app/utils/backend/objectUtils.js
@@ -1,3 +1,3 @@
-export function isEmpty (object) {
+export function isEmptyObject (object) {
     return Object.keys(object).length === 0;
 }

--- a/app/utils/backend/objectUtils.js
+++ b/app/utils/backend/objectUtils.js
@@ -1,0 +1,3 @@
+export function isEmpty (object) {
+    return Object.keys(object).length === 0;
+}

--- a/app/utils/backend/validators/comments.js
+++ b/app/utils/backend/validators/comments.js
@@ -28,3 +28,9 @@ export const deleteCommentSchema = Joi.object().keys({
   userEmail: EMAIL_VALIDATION,
 });
 
+export const approvedByCommentSchema = Joi.object().keys({
+  commentId: JOI_ID_VALIDATION.required(), 
+  questionId: SIMPLE_INTEGER_VALIDATION.required(),
+  employeeId : SIMPLE_INTEGER_VALIDATION.required(),
+  checked: Joi.boolean().required(),
+})

--- a/tests/integration/controllers/comments/approvedComment.test.js
+++ b/tests/integration/controllers/comments/approvedComment.test.js
@@ -1,0 +1,50 @@
+import {approvedByComment} from '~/controllers/comments/approvedBy';
+
+describe('approve comment controller', () => {
+
+    it('approve a comment as an answer', async() => {
+        const params ={
+            questionId:10,
+            commentId:10,
+            employeeId: 1, 
+            checked: true
+        };
+       const response = await approvedByComment(params);
+       expect(response).toBeDefined();
+       expect(response.success).toBe(true);
+       expect(response.response).toBe('Comment marked as an answer successfully');
+    });
+
+    it('unmark a comment approved', async() => {
+        let params ={
+            questionId:10,
+            commentId:10,
+            employeeId: 1, 
+            checked: true
+        };
+       const response = await approvedByComment(params);
+       expect(response).toBeDefined();
+       expect(response.success).toBe(true);
+       expect(response.response).toBe('Comment marked as an answer successfully');
+       params.checked = false;
+
+       const responseUnmark = await approvedByComment(params);
+       expect(responseUnmark).toBeDefined();
+       expect(responseUnmark.success).toBe(true);
+       expect(responseUnmark.response).toBe('Comment unmarked as an answer successfully');
+    });
+
+    it('error when question has a comment approved as an answer', async()=>{
+        let params ={
+            questionId:9,
+            commentId:6,
+            employeeId: 1, 
+            checked: true
+        };
+       const response = await approvedByComment(params);
+       expect(response).toBeDefined();
+       expect(response.errors).toBeDefined();
+       expect(response.errors[0].message).toBe('This question already has a comment as answer');
+      
+    })
+})


### PR DESCRIPTION
#### What does this PR do?
- Add controller to approve a comment as answer.

#### Where should the reviewer start?
 - app/controllers/comments/approvedBy.js
 - tests/integration/controllers/comments/approvedComment.test.js

#### How should this be manually tested?
Run the test integration. `npm run test:integration`

#### What are the relevant tickets?
(Link to issues, related PR, JIRA issues, etc.)
Closes #59 

#### Screenshots
<img width="1184" alt="Screen Shot 2022-11-01 at 17 50 46" src="https://user-images.githubusercontent.com/97203617/199363194-7ef6adf2-f5bc-4032-9ed6-9fba66c71947.png">
