### PR TITLE
fix: error when pinning question from the list and retain filtering/ordering query parameters

### DIFF
--- a/app/components/QuestionRow/QuestionRow.jsx
+++ b/app/components/QuestionRow/QuestionRow.jsx
@@ -50,6 +50,10 @@ const QuestionRow = (props) => {
       url = `/questions/${question.question_id}`
       const urlSearchParam = searchParams.get('order');
       url = urlSearchParam !== null ? `${url}?order=${urlSearchParam}` : url;
+    } else {
+      searchParams.forEach((value, key) => {
+        url += value ? `&${key}=${value}` : '';
+      });
     }
     const newPinStatusValue = question.is_pinned ? 'false' : 'true';
     const data = new FormData(pinForm.current);

--- a/app/controllers/questions/modifyPinStatus.js
+++ b/app/controllers/questions/modifyPinStatus.js
@@ -1,9 +1,9 @@
 import { PIN_QUESTION_ERROR_MESSAGE, INVALID_PARAMS_FOR_OPERATION_ERROR_MESSAGE, QUESTION_NOT_FOUND_ERROR_MESSAGE } from "~/utils/constants";
-import { modifyQuestionPinStatusParms } from "~/utils/backend/validators/question";
+import { modifyQuestionPinStatusParams } from "~/utils/backend/validators/question";
 import { db } from "~/utils/db.server";
 
 export const modifyPinStatus = async (questionId, newPinStatus) => {
-  const { error, value } = modifyQuestionPinStatusParms.validate({
+  const { error, value } = modifyQuestionPinStatusParams.validate({
     questionId,
     newPinStatus,
   });
@@ -23,7 +23,7 @@ export const modifyPinStatus = async (questionId, newPinStatus) => {
       data: { is_pinned: value.newPinStatus },
     });
     return {
-      success: `The question has been ${updatedQuestion.is_pinned ? 'pinned' : 'unpinned'}`,
+      success: `The question has been ${updatedQuestion.is_pinned ? 'pinned' : 'unpinned'}.`,
       question: updatedQuestion,
     }
 

--- a/app/routes/index.jsx
+++ b/app/routes/index.jsx
@@ -58,10 +58,12 @@ export const action = async ({ request }) => {
       const questionId = parseInt(formData.get("questionId"));
       const value = formData.get("value") !== 'false';
       response = await modifyPinStatus(questionId, value);
+      break;
     case ACTIONS.VOTE_QUESTION:
       const voteQuestionId = parseInt(formData.get("questionId"));
       const voteQuestionUser = JSON.parse(formData.get("user"));
       response = await voteQuestion(voteQuestionId, voteQuestionUser);
+      break;
   }
 
   return json(response);

--- a/app/utils/backend/validators/question.js
+++ b/app/utils/backend/validators/question.js
@@ -12,7 +12,7 @@ export const createQuestionSchema = Joi.object().keys({
   assigned_department: Joi.number().integer().min(1).allow(null),
 });
 
-export const modifyQuestionPinStatusParms = Joi.object().keys({
+export const modifyQuestionPinStatusParams = Joi.object().keys({
   questionId: Joi.number().integer().required().min(1),
   newPinStatus: Joi.boolean().required(),
 });

--- a/tests/integration/controllers/questions/modifyPinStatus.test.js
+++ b/tests/integration/controllers/questions/modifyPinStatus.test.js
@@ -77,7 +77,7 @@ describe("questions controller", () => {
       expect(response.error).toBeUndefined();
       expect(response.success).toBeDefined();
       expect(response.question).toBeDefined();
-      expect(response.success).toBe('The question has been pinned');
+      expect(response.success).toContain('The question has been pinned');
       expect(response.question.is_pinned).toBeDefined();
       expect(response.question.is_pinned).toBe(true);
       expect(dbUpdateSpy).toHaveBeenCalledTimes(2);
@@ -88,7 +88,7 @@ describe("questions controller", () => {
       expect(response.error).toBeUndefined();
       expect(response.success).toBeDefined();
       expect(response.question).toBeDefined();
-      expect(response.success).toBe('The question has been pinned');
+      expect(response.success).toContain('The question has been pinned');
       expect(response.question.is_pinned).toBeDefined();
       expect(response.question.is_pinned).toBe(true);
       expect(getFormattedDate(response.question.updatedAt)).toEqual(getFormattedDate(new Date()));


### PR DESCRIPTION
#### What does this PR do?

- It fixes the bug parameter error message when pinning/unpinning a question in the question list
- It adds the filtering/ordering query parameters after submitting the pin/unpin action


https://user-images.githubusercontent.com/104774638/200457456-75aea4d8-3351-4e93-be93-cd40460e0d2f.mov



#### Where should the reviewer start?
- app/routes/index.jsx
- app/components/QuestionRow/QuestionRow.jsx

#### How should this be manually tested?
(List of steps to reproduce, corroborate or tests to run. Write this section clear enough so that external users can also follow it and test the fix.)

Pin/unpin a question from the question list having some filtering/ordering parameters selected, the question must be pinned/unpinned correctly without displaying an error message and the query parameters must be kept.

#### Any background context you want to provide?
This is to fix the bug when pinning/unpinning a question issue.

#### What are the relevant tickets?
(Link to issues, related PR, JIRA issues, etc.)
Closes #71 