### PR TITLE
feat: add slack notifications

### DIFF
--- a/app/controllers/answers/create.js
+++ b/app/controllers/answers/create.js
@@ -45,7 +45,7 @@ export const createAnswer = async (body) => {
   });
 
   await slack.createAnswerNotification({
-    questionId: answer.question_id,
+    questionId: relatedQuestion.question_id,
     questionBody: stripNewLines(relatedQuestion.question),
     answerBody: answer.answer_text,
   });

--- a/app/controllers/answers/nps/create.js
+++ b/app/controllers/answers/nps/create.js
@@ -14,7 +14,7 @@ export const createNPS = async (params) => {
   }
 
   try {
-    const { score, answer_id, user, accessToken } = value;
+    const { score, answer_id, user } = value;
 
     const npmCreated = await db.Nps.create({
       data: {

--- a/app/controllers/questions/create.js
+++ b/app/controllers/questions/create.js
@@ -2,7 +2,6 @@ import { DEFAULT_ERROR_MESSAGE } from "~/utils/backend/constants";
 import generateSessionIdHash from "~/utils/backend/crypto";
 import slack from '~/utils/backend/slackNotifications';
 import { stripNewLines, truncate } from '~/utils/backend/stringUtils';
-
 import { sanitizeHTML } from "~/utils/backend/sanitizer";
 import { createQuestionSchema } from "~/utils/backend/validators/question";
 import { db } from "~/utils/db.server"
@@ -10,7 +9,6 @@ import { SLACK_QUESTION_LIMIT } from "~/utils/backend/slackConstants";
 
 export const createQuestion = async (body) => {
   const { error, value } = createQuestionSchema.validate(body);
-
   if (error) {
     return {
       errors: [
@@ -44,7 +42,10 @@ export const createQuestion = async (body) => {
     });
   }
 
-  await slack.question(stripNewLines(truncate(value.question), SLACK_QUESTION_LIMIT));
+  await slack.createQuestionNotification({
+    questionBody: stripNewLines(truncate(value.question), SLACK_QUESTION_LIMIT),
+    questionId: created.question_id,
+  });
 
   return {
     success: "Question has been created succesfully!",

--- a/app/routes/questions/new.jsx
+++ b/app/routes/questions/new.jsx
@@ -31,13 +31,13 @@ export const action = async ({request}) => {
 
   const user = await getAuthenticatedUser(request);
   
-  const parsedDeparment = parseInt(form.assignedDepartment);
+  const parsedDepartment = parseInt(form.assignedDepartment);
 
   const payload = {
     question: form.question,
-    created_by_employee_id: user.employee_id,
+    created_by_employee_id: form.isAnonymous === 'true' ? null : user.employee_id,
     is_anonymous: form.isAnonymous === 'true',
-    assigned_department: Number.isNaN(parsedDeparment) ? null : parsedDeparment,
+    assigned_department: Number.isNaN(parsedDepartment) ? null : parsedDepartment,
     location: form.location,
     accessToken: user.accessToken,
   };
@@ -48,7 +48,7 @@ export const action = async ({request}) => {
     const session = await getSession(request);
     session.flash("globalSuccess", response.success);
   
-    return redirect("/", {
+    return redirect("/?index", {
         headers: {
           "Set-Cookie": await commitSession(session)
         }

--- a/app/utils/backend/slackNotifications.js
+++ b/app/utils/backend/slackNotifications.js
@@ -1,5 +1,5 @@
 import slackNotify from 'slack-notify';
-import { DEFAULT_DOMAIN, DEFAULT_SLACK_NAME, SLACK_ANSWER_COLOR, SLACK_ANSWER_EMOJI, SLACK_ANSWER_HEADER, SLACK_ANSWER_UPDATED_HEADER, SLACK_FALLBACK_STRING, SLACK_MAX_MESSAGE_SIZE_IN_BYTES, SLACK_QUESTION_DETAILS, SLACK_QUESTION_SEE_MORE } from '~/utils/backend/slackConstants';
+import { DEFAULT_DOMAIN, DEFAULT_SLACK_NAME, SLACK_ANSWER_COLOR, SLACK_ANSWER_EMOJI, SLACK_ANSWER_HEADER, SLACK_FALLBACK_STRING, SLACK_MAX_MESSAGE_SIZE_IN_BYTES, SLACK_QUESTION_COLOR, SLACK_QUESTION_DETAILS, SLACK_QUESTION_EMOJI, SLACK_QUESTION_HEADER, SLACK_QUESTION_SEE_MORE } from '~/utils/backend/slackConstants';
 import { getStringSizeInBytes, truncateStringByBytes } from "./stringUtils";
 
 const slack = slackNotify(process.env.SLACK_WEBHOOK_URL);
@@ -21,7 +21,6 @@ async function send(options) {
       },
     ],
   };
-
   await slack.send(defaults);
 }
 
@@ -31,7 +30,7 @@ function buildUrl(questionId) {
 }
 
 
-async function answer({ questionId, questionBody, answerBody, isUpdated }) {
+async function createAnswerNotification({ questionId, questionBody, answerBody }) {
   if (!process.env.SLACK_WEBHOOK_URL) {
     return;
   }
@@ -71,16 +70,14 @@ async function answer({ questionId, questionBody, answerBody, isUpdated }) {
       text,
       footer,
       color: SLACK_ANSWER_COLOR,
-      pretext: isUpdated
-        ? SLACK_ANSWER_UPDATED_HEADER
-        : SLACK_ANSWER_HEADER,
+      pretext: SLACK_ANSWER_HEADER,
     },
   };
 
   await send(options);
 }
 
-async function question(questionBody, questionId) {
+async function createQuestionNotification({questionBody, questionId}) {
   if (!process.env.SLACK_WEBHOOK_URL) {
     return;
   }
@@ -102,12 +99,12 @@ async function question(questionBody, questionId) {
   const footer = `<${url}|${footerBody}>`;
 
   const options = {
-    icon_emoji: SLACK_ANSWER_EMOJI,
+    icon_emoji: SLACK_QUESTION_EMOJI,
     attachments: {
       text,
       footer,
-      color: SLACK_ANSWER_COLOR,
-      pretext: SLACK_ANSWER_HEADER,
+      color: SLACK_QUESTION_COLOR,
+      pretext: SLACK_QUESTION_HEADER,
     },
   };
 
@@ -115,6 +112,6 @@ async function question(questionBody, questionId) {
 }
 
 export default {
-  question,
-  answer,
-};
+  createQuestionNotification,
+  createAnswerNotification
+}

--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -14,8 +14,8 @@ module "cloud_run" {
   auth0_client_secret = data.google_secret_manager_secret_version.Auth0_client_secret.secret_data
   auth0_domain        = data.google_secret_manager_secret_version.Auth0_domain.secret_data
   node_env            = data.google_secret_manager_secret_version.Node_env.secret_data
-  // slack_webhook_url   = data.google_secret_manager_secret_version.Slack_webhook_url.secret_data
-  // slack_wizeq_domain  = data.google_secret_manager_secret_version.Slack_wizeq_domain.secret_data
+  slack_webhook_url   = data.google_secret_manager_secret_version.Slack_webhook_url.secret_data
+  slack_wizeq_domain  = data.google_secret_manager_secret_version.Slack_wizeq_domain.secret_data
   db_url         = "mysql://${data.google_secret_manager_secret_version.Db_user.secret_data}:${data.google_secret_manager_secret_version.Db_password.secret_data}@${module.cloud_sql.db_host}/${data.google_secret_manager_secret_version.Db_name.secret_data}"
   base_url       = data.google_secret_manager_secret_version.Wizeq_url.secret_data
   session_secret = data.google_secret_manager_secret_version.Session_secret.secret_data

--- a/infrastructure/terraform/modules/cloud_run/cloud_run.tf
+++ b/infrastructure/terraform/modules/cloud_run/cloud_run.tf
@@ -32,14 +32,14 @@ resource "google_cloud_run_service" "app" {
           name  = "NODE_ENV"
           value = var.node_env
         }
-        # env {
-        #   name  = "SLACK_WEBHOOK_URL"
-        #   value = var.slack_webhook_url
-        # }
-        # env {
-        #   name  = "SLACK_WIZEQ_DOMAIN"
-        #   value = var.slack_wizeq_domain
-        # }
+        env {
+          name  = "SLACK_WEBHOOK_URL"
+          value = var.slack_webhook_url
+        }
+        env {
+          name  = "SLACK_WIZEQ_DOMAIN"
+          value = var.slack_wizeq_domain
+        }
         env {
           name  = "DATABASE_URL"
           value = var.db_url

--- a/infrastructure/terraform/modules/cloud_run/variables.tf
+++ b/infrastructure/terraform/modules/cloud_run/variables.tf
@@ -56,13 +56,13 @@ variable "node_env" {
   type = string
 }
 
-# variable "slack_webhook_url" {
-#   type = string
-# }
+variable "slack_webhook_url" {
+  type = string
+}
 
-# variable "slack_wizeq_domain" {
-#   type = string
-# }
+variable "slack_wizeq_domain" {
+  type = string
+}
 
 variable "db_url" {
   type = string

--- a/tests/integration/controllers/answers/createAnswer.test.js
+++ b/tests/integration/controllers/answers/createAnswer.test.js
@@ -1,8 +1,10 @@
 import { createAnswer } from '~/controllers/answers/create';
 import { db } from '~/utils/db.server';
+import slack from '~/utils/backend/slackNotifications';
 
 describe('createAnswer', () => {
   const dbCreateSpy = jest.spyOn(db.Answers, 'create');
+  const slackSpy = jest.spyOn(slack, "createAnswerNotification").mockImplementation();
 
   it('creates valid answer', async () => {
     const answer = {
@@ -18,5 +20,6 @@ describe('createAnswer', () => {
     expect(response.answer).toBeDefined();
 
     expect(dbCreateSpy).toHaveBeenCalled();
+    expect(slackSpy).toHaveBeenCalled();
   });
 });

--- a/tests/integration/controllers/questions/createQuestion.test.js
+++ b/tests/integration/controllers/questions/createQuestion.test.js
@@ -6,7 +6,7 @@ import slack from '~/utils/backend/slackNotifications';
   describe("createQuestion", () => {
     const dbCreateSpy = jest.spyOn(db.Questions, 'create');
     const dbUpdateSpy = jest.spyOn(db.Questions, 'update');
-    const slackSpy = jest.spyOn(slack, "question").mockImplementation();
+    const slackSpy = jest.spyOn(slack, "createQuestionNotification").mockImplementation();
 
     it("returns error when inavlid parameters passed", async () => {
 


### PR DESCRIPTION
#### What does this PR do?
- Fixes bug that slackNotifications had when re-implementing
- Changes the url format to match the new question detail URL
- Adds the notification to answer controller and corresponding test
- Adds environment variable to Cloud Run through Terraform

#### Where should the reviewer start?
- Go to #wizeq-dev channel to see the latest bot posts, these were sent through the app locally


#### How should this be manually tested?
Testing locally would require having some .env variables in your local with the Slack credentials. If you are interested I can send them to you in private message.

#### Any background context you want to provide?
Style, message, everything pretty much is reused from old app. Old links will be handled with #72 

#### What are the relevant tickets?
Closes #81 
