### PR TITLE
fix: redirect from old link question. 

### DIFF
--- a/app/routes/index.jsx
+++ b/app/routes/index.jsx
@@ -78,7 +78,7 @@ export default function Index() {
   const fetcher = useFetcher();
   const [shouldFetch, setShouldFetch] = useState(true);
   const [page, setPage] = useState(2);
-  const [isLoading, setIsLoadign] = useState(true);
+  const [isLoading, setIsLoading] = useState(true);
   const [searchParams, ] = useSearchParams();
   const location = useLocation();
   const navigate = useNavigate();
@@ -96,12 +96,11 @@ export default function Index() {
         navigate(`/questions/${questionId}`);
       }
       else {
-        setIsLoadign(false);
-        //To-Do Redirect to Not Found Question Page.
+        setIsLoading(false);
       }
     }
     else{
-      setIsLoadign(false);
+      setIsLoading(false);
     }
   }, [])
 


### PR DESCRIPTION
#### What does this PR do?
- Add support for the old questions links for the details : ` https://questions.wizeline.com/#/?questionId=1440 `

#### Where should the reviewer start?
-  /app/routes/index.jsx

#### How should this be manually tested?
1. Checkout for this branch `frontend/add-redict-to-legacy-url-question`
2. Run the project 
3. Login
4. Go to the next old links:
       http://localhost:3000/#/?questionId=1   - _redirect to the question detail_
       http://localhost:3000/#/?questionId=10  - _redirect to the question detail_
       http://localhost:3000/#/?questionId=2 - _redirect to the question detail_ 
       http://localhost:3000/#/?questionId=Hola - _stay on the homepage_
5. Replace the questionId with another id in your local environment. and verify can you can acces to the detail
      http://localhost:3000/#/?questionId={replace_id}

#### What are the relevant tickets?
(Link to issues, related PR, JIRA issues, etc.)
Closes #72

#### Screenshots

https://user-images.githubusercontent.com/97203617/201414367-d88b1a21-74c5-4cc8-8141-81c3dc91cc1c.mov


