### PR TITLE
refactor: replace instances of controller response "success" with "successMessage"

### DIFF
--- a/app/components/AdminUsersTable/AdminUsersTable.jsx
+++ b/app/components/AdminUsersTable/AdminUsersTable.jsx
@@ -24,7 +24,7 @@ function AdminUsersTable({users, currentPage, totalPages, isLoading, searchTerm,
   const data = useActionData();
 
   useEffect(() => {
-    if (data && data.success) {
+    if (data && data.successMessage) {
       setModal(false);
     }
   }, [users, data])

--- a/app/components/Notifications/Notifications.jsx
+++ b/app/components/Notifications/Notifications.jsx
@@ -14,7 +14,7 @@ const Notifications = () => {
     }
     if (!data) return;
     
-    const { error, errors, success, warnings } = data;
+    const { error, errors, successMessage, warnings } = data;
 
     if (error) {
       console.error(error.detail);
@@ -34,8 +34,8 @@ const Notifications = () => {
       });
     };
 
-    if (success) {
-      toast.success(success, DEFAULT_TOAST_CONFIG);
+    if (successMessage) {
+      toast.success(successMessage, DEFAULT_TOAST_CONFIG);
     };
   }, [data, globalSuccess]);
 

--- a/app/controllers/answers/create.js
+++ b/app/controllers/answers/create.js
@@ -51,7 +51,7 @@ export const createAnswer = async (body) => {
   });
 
   return {
-    success: 'Answer has been created successfully.',
+    successMessage: 'Answer has been created successfully.',
     answer,
   };
 };

--- a/app/controllers/answers/delete.js
+++ b/app/controllers/answers/delete.js
@@ -26,6 +26,6 @@ export const deleteAnswer = async (query) => {
   });
 
   return {
-    success: 'Answer has been deleted succesfully.',
+    successMessage: 'Answer has been deleted succesfully.',
   };
 };

--- a/app/controllers/answers/getAnswerById.js
+++ b/app/controllers/answers/getAnswerById.js
@@ -27,7 +27,7 @@ export const getAnswerById = async (answerId, user) => {
     });
 
     return {
-      success: 'Answer successfully read!',
+      successMessage: 'Answer successfully read!',
       answer,
     };
   } catch (error) {

--- a/app/controllers/answers/nps/delete.js
+++ b/app/controllers/answers/nps/delete.js
@@ -23,7 +23,7 @@ export const deleteNPS = async (params) => {
     });
 
     return{
-      success: 'NetScore has been deleted succesfully.',
+      successMessage: 'NetScore has been deleted succesfully.',
     }
 
   }

--- a/app/controllers/answers/nps/nps.js
+++ b/app/controllers/answers/nps/nps.js
@@ -19,7 +19,7 @@ export const nps = async (query) => {
     })
 
     return {
-        success:'Score has been assigned successfully',
+        successMessage:'Score has been assigned successfully',
         scored
     } 
 } catch (error) {

--- a/app/controllers/answers/update.js
+++ b/app/controllers/answers/update.js
@@ -28,7 +28,7 @@ export const updateAnswer = async (query) => {
   });
 
   return {
-    success: 'Answer has been updated succesfully.',
+    successMessage: 'Answer has been updated succesfully.',
     updatedAnswer,
   };
 };

--- a/app/controllers/comments/approvedBy.js
+++ b/app/controllers/comments/approvedBy.js
@@ -60,7 +60,7 @@ export const approvedByComment = async(params) => {
     }
 
     return {
-        success: `Comment ${checked? 'marked' : 'unmarked'} as an answer successfully`,
+        successMessage: `Comment ${checked? 'marked' : 'unmarked'} as an answer successfully`,
         response: `Comment ${checked? 'marked' : 'unmarked'} as an answer successfully`,
     };
 }

--- a/app/controllers/comments/create.js
+++ b/app/controllers/comments/create.js
@@ -65,7 +65,7 @@ export const createComment = async (data) => {
   }
 
   return {
-    success: "Comment has been created succesfully.",
+    successMessage: "Comment has been created succesfully.",
     comment: commentResponse,
   };
 };

--- a/app/controllers/comments/delete.js
+++ b/app/controllers/comments/delete.js
@@ -74,7 +74,7 @@ export const deleteComment = async (body) => {
   }
   if (deleteCommentResponse.count === 1) {
     return {
-      success: "Comment was deleted successfully",
+      successMessage: "Comment was deleted successfully",
     };
   }
 

--- a/app/controllers/comments/list.js
+++ b/app/controllers/comments/list.js
@@ -85,5 +85,5 @@ const comments = fetchComments.map((comment) => {
 
     return comment;
 });
-return { success: true, comments};
+return { comments };
 }

--- a/app/controllers/comments/update.js
+++ b/app/controllers/comments/update.js
@@ -72,7 +72,7 @@ export const updateComment = async (body) => {
   }
   if (updateCommentResponse.count === 1) {
     return {
-      success: true,
+      successMessage: "Comment was updated successfully!",
       response: "Comment was updated successfully",
     };
   }

--- a/app/controllers/questionVotes/voteQuestion.js
+++ b/app/controllers/questionVotes/voteQuestion.js
@@ -51,7 +51,6 @@ export const voteQuestion = async (questionId, user) => {
       });
 
       return {
-        success: true,
         response: {
           vote: newVote,
           upVoteCount: targetQuestion._count.Votes + 1,
@@ -62,7 +61,6 @@ export const voteQuestion = async (questionId, user) => {
     try {
       const deletedVote = await db.Votes.delete({ where: { id: voteByUser.id } });
       return {
-        success: true,
         response: {
           voteSuccessfullyDeleted: true,
           deletedVote,

--- a/app/controllers/questions/assignQuestion.js
+++ b/app/controllers/questions/assignQuestion.js
@@ -21,7 +21,7 @@ try {
     })
 
     return{
-        success:'Department has been assigned successfully',
+        successMessage:'Department has been assigned successfully',
         assignedQuestion
     } 
 } catch (error) {

--- a/app/controllers/questions/create.js
+++ b/app/controllers/questions/create.js
@@ -48,7 +48,7 @@ export const createQuestion = async (body) => {
   });
 
   return {
-    success: "Question has been created succesfully!",
+    successMessage: "Question has been created succesfully!",
     question: created,
   };
 }

--- a/app/controllers/questions/getQuestionById.js
+++ b/app/controllers/questions/getQuestionById.js
@@ -83,7 +83,7 @@ export const getQuestionById = async (questionId, user) => {
       }
 
       return {
-        success: true,
+        successMessage: true,
         question: mappedQuestion,
       }
 

--- a/app/controllers/questions/modifyPinStatus.js
+++ b/app/controllers/questions/modifyPinStatus.js
@@ -23,7 +23,7 @@ export const modifyPinStatus = async (questionId, newPinStatus) => {
       data: { is_pinned: value.newPinStatus },
     });
     return {
-      success: `The question has been ${updatedQuestion.is_pinned ? 'pinned' : 'unpinned'}.`,
+      successMessage: `The question has been ${updatedQuestion.is_pinned ? 'pinned' : 'unpinned'}.`,
       question: updatedQuestion,
     }
 

--- a/app/controllers/users/update.js
+++ b/app/controllers/users/update.js
@@ -28,7 +28,7 @@ export const updateUser = async (query) => {
     });
 
     return {
-        success: 'User has been updated succesfully.',
+        successMessage: 'User has been updated succesfully.',
         updatedUser: updatedUser,
     };
 }

--- a/app/routes/questions/new.jsx
+++ b/app/routes/questions/new.jsx
@@ -44,7 +44,7 @@ export const action = async ({request}) => {
 
   const response = await createQuestion(payload);
 
-  if (response.success) {
+  if (response.successMessage) {
     const session = await getSession(request);
     session.flash("globalSuccess", response.successMessage);
   

--- a/app/routes/questions/new.jsx
+++ b/app/routes/questions/new.jsx
@@ -46,7 +46,7 @@ export const action = async ({request}) => {
 
   if (response.success) {
     const session = await getSession(request);
-    session.flash("globalSuccess", response.success);
+    session.flash("globalSuccess", response.successMessage);
   
     return redirect("/?index", {
         headers: {

--- a/tests/integration/controllers/answers/createAnswer.test.js
+++ b/tests/integration/controllers/answers/createAnswer.test.js
@@ -16,7 +16,7 @@ describe('createAnswer', () => {
     const response = await createAnswer(answer);
 
     expect(response).toBeDefined();
-    expect(response.success).toBeDefined();
+    expect(response.successMessage).toBeDefined();
     expect(response.answer).toBeDefined();
 
     expect(dbCreateSpy).toHaveBeenCalled();

--- a/tests/integration/controllers/answers/deleteAnswer.test.js
+++ b/tests/integration/controllers/answers/deleteAnswer.test.js
@@ -8,6 +8,6 @@ describe('deleteAnswer', () => {
 
     const response = await deleteAnswer(payload);
     expect(response).toBeDefined();
-    expect(response.success).toBeDefined();
+    expect(response.successMessage).toBeDefined();
   });
 });

--- a/tests/integration/controllers/answers/getAnswerById.test.js
+++ b/tests/integration/controllers/answers/getAnswerById.test.js
@@ -51,8 +51,8 @@ describe('answers controller', () => {
         id: 'google-oauth2|108653070533260305238',
       });
       expect(response).toBeDefined();
-      expect(response.success).toBeDefined();
-      expect(response.success).toBe('Answer successfully read!');
+      expect(response.successMessage).toBeDefined();
+      expect(response.successMessage).toBe('Answer successfully read!');
       expect(response.answer).toBeDefined();
 
       const answer = response.answer;

--- a/tests/integration/controllers/answers/nps/deleteNpm.test.js
+++ b/tests/integration/controllers/answers/nps/deleteNpm.test.js
@@ -8,8 +8,8 @@ describe('nps delete controller', () => {
         }
         const response = await deleteNPS(params);
         expect(response).toBeDefined();
-        expect(response.success).toBeDefined();
-        expect(response.success).toBe('NetScore has been deleted succesfully.');
+        expect(response.successMessage).toBeDefined();
+        expect(response.successMessage).toBe('NetScore has been deleted succesfully.');
     })
     it('error when the netscore not exist', async() => {
         const params ={ id: 10, user: {id: 'google-oauth2|111766391199351256706' }};

--- a/tests/integration/controllers/answers/nps/nps.test.js
+++ b/tests/integration/controllers/answers/nps/nps.test.js
@@ -9,7 +9,7 @@ describe('nps', () => {
 
         const response = await nps(payload);
         expect(response).toBeDefined();
-        expect(response.success).toBeDefined();
+        expect(response.successMessage).toBeDefined();
         expect(response.scored.score).toEqual(payload.score);
     })
 

--- a/tests/integration/controllers/answers/updateAnswer.test.js
+++ b/tests/integration/controllers/answers/updateAnswer.test.js
@@ -16,7 +16,7 @@ describe('updateAnswer', () => {
 
     const response = await updateAnswer(payload);
     expect(response).toBeDefined();
-    expect(response.success).toBeDefined();
+    expect(response.successMessage).toBeDefined();
 
     expect(response.updatedAnswer.answer_text).toEqual(payload.answer_text);
   });
@@ -37,7 +37,7 @@ describe('updateAnswer', () => {
 
     const response = await updateAnswer(payload);
     expect(response).toBeDefined();
-    expect(response.success).toBeDefined();
+    expect(response.successMessage).toBeDefined();
     expect(getFormattedDate(response.updatedAnswer.updatedAt)).toEqual(getFormattedDate(new Date()));
   })
 });

--- a/tests/integration/controllers/comments/approvedComment.test.js
+++ b/tests/integration/controllers/comments/approvedComment.test.js
@@ -11,7 +11,7 @@ describe('approve comment controller', () => {
         };
        const response = await approvedByComment(params);
        expect(response).toBeDefined();
-       expect(response.success).toBe('Comment marked as an answer successfully');
+       expect(response.successMessage).toBe('Comment marked as an answer successfully');
        expect(response.response).toBe('Comment marked as an answer successfully');
     });
 
@@ -25,12 +25,12 @@ describe('approve comment controller', () => {
        const response = await approvedByComment(params);
        expect(response).toBeDefined();
        expect(response.response).toBe('Comment marked as an answer successfully');
-       expect(response.success).toBe('Comment marked as an answer successfully');
+       expect(response.successMessage).toBe('Comment marked as an answer successfully');
        params.checked = false;
 
        const responseUnmark = await approvedByComment(params);
        expect(responseUnmark).toBeDefined();
-       expect(responseUnmark.success).toBe('Comment unmarked as an answer successfully');
+       expect(responseUnmark.successMessage).toBe('Comment unmarked as an answer successfully');
        expect(responseUnmark.response).toBe('Comment unmarked as an answer successfully');
     });
 

--- a/tests/integration/controllers/comments/createComment.test.js
+++ b/tests/integration/controllers/comments/createComment.test.js
@@ -38,7 +38,7 @@ describe('createComment', () => {
     const response = await createComment(comment);
 
     expect(response).toBeDefined();
-    expect(response.success).toBeDefined();
+    expect(response.successMessage).toBeDefined();
     expect(response.comment).toBeDefined();
 
     expect(response.comment.createdAt).toBeDefined();
@@ -64,7 +64,7 @@ describe('createComment', () => {
     const response = await createComment(comment);
 
     expect(response).toBeDefined();
-    expect(response.success).toBeDefined();
+    expect(response.successMessage).toBeDefined();
     expect(response.comment).toBeDefined();
     
     expect(response.comment.createdAt).toBeDefined();

--- a/tests/integration/controllers/comments/deleteComment.test.js
+++ b/tests/integration/controllers/comments/deleteComment.test.js
@@ -75,7 +75,7 @@ describe('delete comment controller', () => {
 
         const createCommentResponse = await createComment(createCommentBody);
 
-        expect(createCommentResponse.success).toBeDefined();
+        expect(createCommentResponse.successMessage).toBeDefined();
         expect(createCommentResponse.comment.id).toBeDefined();
         expect(typeof createCommentResponse.comment.id).toBe('number');
 
@@ -84,8 +84,8 @@ describe('delete comment controller', () => {
 
         const deleteCommentResponse = await deleteComment(deleteCommentBody);
         expect(deleteCommentResponse).toBeDefined();
-        expect(deleteCommentResponse.success).toBeDefined();
-        expect(deleteCommentResponse.success).toBe('Comment was deleted successfully');
+        expect(deleteCommentResponse.successMessage).toBeDefined();
+        expect(deleteCommentResponse.successMessage).toBe('Comment was deleted successfully');
         expect(dbDeleteManyCommentSpy).toHaveBeenCalledTimes(1);
     });
 
@@ -107,7 +107,7 @@ describe('delete comment controller', () => {
 
         const createCommentResponse = await createComment(createCommentBody);
 
-        expect(createCommentResponse.success).toBeDefined();
+        expect(createCommentResponse.successMessage).toBeDefined();
         expect(createCommentResponse.comment.id).toBeDefined();
         expect(typeof createCommentResponse.comment.id).toBe('number');
 
@@ -116,8 +116,8 @@ describe('delete comment controller', () => {
 
         const deleteCommentResponse = await deleteComment(deleteCommentBody);
         expect(deleteCommentResponse).toBeDefined();
-        expect(deleteCommentResponse.success).toBeDefined();
-        expect(deleteCommentResponse.success).toBe('Comment was deleted successfully');
+        expect(deleteCommentResponse.successMessage).toBeDefined();
+        expect(deleteCommentResponse.successMessage).toBe('Comment was deleted successfully');
         expect(dbDeleteManyCommentSpy).toHaveBeenCalledTimes(1);
     });
 });

--- a/tests/integration/controllers/comments/updateComment.test.js
+++ b/tests/integration/controllers/comments/updateComment.test.js
@@ -81,7 +81,6 @@ describe('update comment controller', () => {
         const updateCommentResponse = await updateComment(updateCommentBody);
         expect(updateCommentResponse).toBeDefined();
         expect(updateCommentResponse.error).toBeUndefined();
-        expect(updateCommentResponse.success).toBe(true);
         expect(updateCommentResponse.response).toBe('Comment was updated successfully');
         expect(dbUpdateManyCommentSpy).toHaveBeenCalledTimes(3);
     });

--- a/tests/integration/controllers/questionVotes.test.js
+++ b/tests/integration/controllers/questionVotes.test.js
@@ -31,11 +31,9 @@ describe('question votes controller', () => {
 
     it('creates new vote for question', async () => {
       const voteResponse = await voteQuestion(3, { id: 'google-oauth2|108653070533267290373' });
-      expect(voteResponse.success).toBe(true);
       expect(voteResponse.response).toBeDefined();
       expect(voteResponse.response.upVoteCount).toBe(4);
       const getQuestionResponse = await getQuestionById(3, { id: 'google-oauth2|108653070533267290373' });
-      expect(getQuestionResponse.success).toBe(true);
       expect(getQuestionResponse.question).toBeDefined();
       expect(getQuestionResponse.question.hasVoted).toBe(true);
       expect(getQuestionResponse.question.num_votes).toBe(4);
@@ -57,7 +55,7 @@ describe('question votes controller', () => {
 
       expect(createQuestionResponse).toBeDefined();
       expect(createQuestionResponse.errors).toBeUndefined();
-      expect(createQuestionResponse.success).toBeDefined();
+      expect(createQuestionResponse.successMessage).toBeDefined();
       expect(createQuestionResponse.question).toBeDefined();
 
       const testQuestionId = createQuestionResponse.question.question_id;
@@ -67,35 +65,29 @@ describe('question votes controller', () => {
       const thirdUser = { id: "google-oauth2|108653070533260303333" };
 
       let voteResponse = await voteQuestion(testQuestionId, firstUser);
-      expect(voteResponse.success).toBe(true);
       expect(voteResponse.response).toBeDefined();
       expect(voteResponse.response.upVoteCount).toBe(1);
 
       voteResponse = await voteQuestion(testQuestionId, secondUser);
-      expect(voteResponse.success).toBe(true);
       expect(voteResponse.response).toBeDefined();
       expect(voteResponse.response.upVoteCount).toBe(2);
 
       voteResponse = await voteQuestion(testQuestionId, thirdUser);
-      expect(voteResponse.success).toBe(true);
       expect(voteResponse.response).toBeDefined();
       expect(voteResponse.response.upVoteCount).toBe(3);
 
       let getQuestionResponse = await getQuestionById(testQuestionId, secondUser);
-      expect(getQuestionResponse.success).toBe(true);
       expect(getQuestionResponse.question).toBeDefined();
       expect(getQuestionResponse.question.hasVoted).toBe(true);
       expect(getQuestionResponse.question.num_votes).toBe(3);
 
       voteResponse = await voteQuestion(testQuestionId, secondUser);
-      expect(voteResponse.success).toBe(true);
       expect(voteResponse.response).toBeDefined();
       expect(voteResponse.response.voteSuccessfullyDeleted).toBe(true);
       expect(voteResponse.response.upVoteCount).toBe(2);
       expect(dbDeleteVoteSpy).toHaveBeenCalledTimes(1);
 
       getQuestionResponse = await getQuestionById(testQuestionId, secondUser);
-      expect(getQuestionResponse.success).toBe(true);
       expect(getQuestionResponse.question).toBeDefined();
       expect(getQuestionResponse.question.hasVoted).toBe(false);
       expect(getQuestionResponse.question.num_votes).toBe(2);

--- a/tests/integration/controllers/questions/assignQuestion.test.js
+++ b/tests/integration/controllers/questions/assignQuestion.test.js
@@ -9,7 +9,7 @@ describe('assignQuestion', () => {
 
         const response = await assignQuestion(payload);
         expect(response).toBeDefined();
-        expect(response.success).toBeDefined();
+        expect(response.successMessage).toBeDefined();
         expect(response.assignedQuestion.assigned_department).toEqual(payload.assigned_department);
     })
 

--- a/tests/integration/controllers/questions/createQuestion.test.js
+++ b/tests/integration/controllers/questions/createQuestion.test.js
@@ -21,7 +21,7 @@ import slack from '~/utils/backend/slackNotifications';
 
       expect(response).toBeDefined();
       expect(response.errors).toBeDefined();
-      expect(response.success).toBeUndefined();
+      expect(response.successMessage).toBeUndefined();
       expect(response.question).toBeUndefined();
 
       expect(dbCreateSpy).toHaveBeenCalledTimes(0);
@@ -41,7 +41,7 @@ import slack from '~/utils/backend/slackNotifications';
         const response = await createQuestion(question);
 
         expect(response).toBeDefined();
-        expect(response.success).toBeDefined();
+        expect(response.successMessage).toBeDefined();
         expect(response.question).toBeDefined();
         expect(response.question.user_hash).toBe('');
 
@@ -65,7 +65,7 @@ import slack from '~/utils/backend/slackNotifications';
       const response = await createQuestion(question);
 
       expect(response).toBeDefined();
-      expect(response.success).toBeDefined();
+      expect(response.successMessage).toBeDefined();
       expect(response.question).toBeDefined();
       expect(response.question.user_hash).not.toBe('');
 

--- a/tests/integration/controllers/questions/getQuestionById.test.js
+++ b/tests/integration/controllers/questions/getQuestionById.test.js
@@ -35,8 +35,8 @@ describe("questions controller", () => {
     it("returns the question with all aggregated properties", async () => {
       const response = await getQuestionById(2, { id: 'google-oauth2|108653070533260305238' });
       expect(response).toBeDefined();
-      expect(response.success).toBeDefined();
-      expect(response.success).toBe(true);
+      expect(response.successMessage).toBeDefined();
+      expect(response.successMessage).toBe(true);
       expect(response.question).toBeDefined();
 
       const question = response.question;

--- a/tests/integration/controllers/questions/modifyPinStatus.test.js
+++ b/tests/integration/controllers/questions/modifyPinStatus.test.js
@@ -21,7 +21,7 @@ describe("questions controller", () => {
       expect(response.error.detail).toBeDefined();
       expect(response.error.message).toBe(PIN_QUESTION_ERROR_MESSAGE);
       expect(response.error.detail).toBe(INVALID_PARAMS_FOR_OPERATION_ERROR_MESSAGE);
-      expect(response.success).toBeUndefined();
+      expect(response.successMessage).toBeUndefined();
       expect(response.question).toBeUndefined();
       expect(dbUpdateSpy).toHaveBeenCalledTimes(0);
     });
@@ -34,7 +34,7 @@ describe("questions controller", () => {
       expect(response.error.detail).toBeDefined();
       expect(response.error.message).toBe(PIN_QUESTION_ERROR_MESSAGE);
       expect(response.error.detail).toBe(INVALID_PARAMS_FOR_OPERATION_ERROR_MESSAGE);
-      expect(response.success).toBeUndefined();
+      expect(response.successMessage).toBeUndefined();
       expect(response.question).toBeUndefined();
       expect(dbUpdateSpy).toHaveBeenCalledTimes(0);
     });
@@ -47,7 +47,7 @@ describe("questions controller", () => {
       expect(response.error.detail).toBeDefined();
       expect(response.error.message).toBe(PIN_QUESTION_ERROR_MESSAGE);
       expect(response.error.detail).toBe(QUESTION_NOT_FOUND_ERROR_MESSAGE);
-      expect(response.success).toBeUndefined();
+      expect(response.successMessage).toBeUndefined();
       expect(response.question).toBeUndefined();
       expect(dbUpdateSpy).toHaveBeenCalledTimes(1);
     });
@@ -66,7 +66,7 @@ describe("questions controller", () => {
 
       expect(createQuestionResponse).toBeDefined();
       expect(createQuestionResponse.errors).toBeUndefined();
-      expect(createQuestionResponse.success).toBeDefined();
+      expect(createQuestionResponse.successMessage).toBeDefined();
       expect(createQuestionResponse.question).toBeDefined();
       expect(createQuestionResponse.question.question_id).toBeDefined();
       expect(createQuestionResponse.question.is_pinned).toBeDefined();
@@ -75,9 +75,9 @@ describe("questions controller", () => {
       const response = await modifyPinStatus(createQuestionResponse.question.question_id, true);
 
       expect(response.error).toBeUndefined();
-      expect(response.success).toBeDefined();
+      expect(response.successMessage).toBeDefined();
       expect(response.question).toBeDefined();
-      expect(response.success).toContain('The question has been pinned');
+      expect(response.successMessage).toContain('The question has been pinned');
       expect(response.question.is_pinned).toBeDefined();
       expect(response.question.is_pinned).toBe(true);
       expect(dbUpdateSpy).toHaveBeenCalledTimes(2);
@@ -86,9 +86,9 @@ describe("questions controller", () => {
     it('return the current date in the updatedAt field when updating a question', async () => {
       const response = await modifyPinStatus(1, true);
       expect(response.error).toBeUndefined();
-      expect(response.success).toBeDefined();
+      expect(response.successMessage).toBeDefined();
       expect(response.question).toBeDefined();
-      expect(response.success).toContain('The question has been pinned');
+      expect(response.successMessage).toContain('The question has been pinned');
       expect(response.question.is_pinned).toBeDefined();
       expect(response.question.is_pinned).toBe(true);
       expect(getFormattedDate(response.question.updatedAt)).toEqual(getFormattedDate(new Date()));

--- a/tests/integration/controllers/users.test.js
+++ b/tests/integration/controllers/users.test.js
@@ -35,7 +35,7 @@ describe("user controllers", () => {
       }
       const response = await updateUser(payload);
       expect(response).toBeDefined();
-      expect(response.success).toBeDefined();
+      expect(response.successMessage).toBeDefined();
 
       expect(response.updatedUser.job_title).toEqual(payload.job_title);
       expect(response.updatedUser.is_admin).toEqual(payload.is_admin);


### PR DESCRIPTION
#### What does this PR do?
- Replace instances of controller response "success" with "successMessage"

#### Where should the reviewer start?
- app/controllers

#### How should this be manually tested?
1. Test all the components that has a success message (Create/edit/delete answer,  create/edit question, etc.)
2. Make sure that the toastify notification is displayed correctly for each action
3. 🎉 

#### What are the relevant tickets?
(Link to issues, related PR, JIRA issues, etc.)
Closes #65 