### PR TITLE
feat: added fallback profile image 

### DIFF
--- a/app/components/Atoms/UserImage/UserImage.jsx
+++ b/app/components/Atoms/UserImage/UserImage.jsx
@@ -1,11 +1,20 @@
+import { useState } from 'react';
 import PropTypes from 'prop-types';
 import * as S from './UserImage.Styled';
 import PlaceHolderImage from '~/images/placeholder_user_img.png';
 
 const UserImage = ({ src, alt, customSize, size }) => {
+  const [imageSrc, setImageSrc] = useState(src);
+
   return (
     <S.Container size={size} customSize={customSize}>
-      <S.Image src={src || PlaceHolderImage} alt={alt} />
+      <S.Image
+        alt={alt}
+        onError={() => {
+          if (imageSrc !== PlaceHolderImage) setImageSrc(PlaceHolderImage);
+        }}
+        src={imageSrc}
+      />
     </S.Container>
   );
 }


### PR DESCRIPTION
#### What does this PR do?
- Added fallback image when profile pictures are not loaded succesfully

#### Where should the reviewer start?
- app/components/Atoms/UserImage

#### How should this be manually tested?
1. Check if the placeholder image is displayed when the profile img is not loaded
2. Check if the profile img is displayed correctly when it's loaded correctly
3. :tada:

#### What are the relevant tickets?
Closes #90 

#### Screenshots
<img width="1440" alt="Captura de Pantalla 2022-11-16 a la(s) 11 30 16" src="https://user-images.githubusercontent.com/71342528/202251679-4717554b-c374-4d82-a4a9-bd40832003ad.png">
