### PR TITLE
fix: add dates for community answers and approved by answers

### DIFF
--- a/app/components/AnswerRow/AnswerRow.jsx
+++ b/app/components/AnswerRow/AnswerRow.jsx
@@ -53,7 +53,19 @@ function AnswerRow({ searchTerm, isPreview, isQuestionModalOpen, ...props }) {
     )
   }
 
-  const { user, createdAt, children } = props;
+  const getAnswerDate = () => {
+    if (props.isCommunityAnswer || props.isCommentApproved) {
+      return props.answered_at;
+    };
+    
+    return props.answer_date
+  }
+
+  const { user, children } = props;
+
+  const anwserDate = getAnswerDate();
+  console.log(props.isCommentApproved ? "Approved" : props.isCommunityAnswer ? "Community" : "Regular")
+  console.log(props);
   return (
     <Styled.AnswerContainer isPreview={isPreview} isQuestionModalOpen={isQuestionModalOpen}>
       <Styled.AnsweredMetadata isPreview={isPreview} >
@@ -63,7 +75,7 @@ function AnswerRow({ searchTerm, isPreview, isQuestionModalOpen, ...props }) {
               <DateContainer hasJobTitle={user !== null ? user.job_title : ''}>
                 <CircleIcon />
                 <Styled.AnswerRowDate isQuestionModalOpen={isQuestionModalOpen}>
-                  {getDateData(createdAt)}
+                  {getDateData(anwserDate)}
                 </Styled.AnswerRowDate>
               </DateContainer>
             </QuestionResponderInfo>


### PR DESCRIPTION
#### What does this PR do?
- Solves problems where new community answers and approved by answers introducces in #84  were shown with incorrect dates.

#### Where should the reviewer start?
Have a community answer and approved by answer in your local. In your local database you can modify a CommentVote row to have more than 10 positives votes, or changing temporarily the [COMMUNITY_ANSWER_VOTE_TRESHOLD ](https://github.com/wizeline/wize-q-remix/blob/5a7e6ec3eff95389a77d7249ee6e4515b918f208/app/utils/backend/constants.js#L21)

#### How should this be manually tested?
1. Do the above to have the relevant type of answers
2. Check that in home, the questions and answers of different types show a correct date (and not "a few seconds ago")

#### What are the relevant tickets?
Closes #100 
