### PR TITLE
fix: deleteComment test intermittent error

### DIFF
--- a/tests/integration/controllers/comments/deleteComment.test.js
+++ b/tests/integration/controllers/comments/deleteComment.test.js
@@ -114,9 +114,10 @@ describe('delete comment controller', () => {
 
 
         deleteCommentBody.commentId = createCommentResponse.comment.id;
-
+        
         const deleteCommentResponse = await deleteComment(deleteCommentBody);
         if(!deleteCommentResponse.successMessage) {
+          console.log(createCommentResponse);
           console.log(deleteCommentResponse);
         }
         expect(deleteCommentResponse).toBeDefined();

--- a/tests/integration/controllers/comments/deleteComment.test.js
+++ b/tests/integration/controllers/comments/deleteComment.test.js
@@ -124,10 +124,7 @@ describe('delete comment controller', () => {
         deleteCommentBody.commentId = createCommentResponse.comment.id;
         
         const deleteCommentResponse = await deleteComment(deleteCommentBody);
-        if(!deleteCommentResponse.successMessage) {
-          console.log(createCommentResponse);
-          console.log(deleteCommentResponse);
-        }
+
         expect(generateMinMaxDatesSpy).toHaveBeenCalledTimes(1);
         expect(deleteCommentResponse).toBeDefined();
         expect(deleteCommentResponse.successMessage).toBeDefined();

--- a/tests/integration/controllers/comments/deleteComment.test.js
+++ b/tests/integration/controllers/comments/deleteComment.test.js
@@ -1,6 +1,7 @@
 import { createComment } from "~/controllers/comments/create";
 import { deleteComment } from "~/controllers/comments/delete";
 import { randomAccessToken } from "./../../../utils";
+import * as commentsUtils from '~/utils/backend/comments';
 
 import { db } from "~/utils/db.server";
 
@@ -91,6 +92,13 @@ describe('delete comment controller', () => {
 
     it('deletes the comment when author session hash matches', async () => {
         const accessToken = randomAccessToken();
+        const generateMinMaxDatesSpy = jest.spyOn(commentsUtils, 'generateMinMaxDates');
+        generateMinMaxDatesSpy.mockImplementation(() => {
+          return {
+            minDate: new Date(1995, 11, 17),
+            maxDate: new Date(3000, 11, 17),
+          }
+        })
 
         const createCommentBody = {
             comment: 'Test delete comment controller',
@@ -120,9 +128,12 @@ describe('delete comment controller', () => {
           console.log(createCommentResponse);
           console.log(deleteCommentResponse);
         }
+        expect(generateMinMaxDatesSpy).toHaveBeenCalledTimes(1);
         expect(deleteCommentResponse).toBeDefined();
         expect(deleteCommentResponse.successMessage).toBeDefined();
         expect(deleteCommentResponse.successMessage).toBe('Comment was deleted successfully');
         expect(dbDeleteManyCommentSpy).toHaveBeenCalledTimes(1);
+
+        generateMinMaxDatesSpy.mockRestore();
     });
 });

--- a/tests/integration/controllers/comments/deleteComment.test.js
+++ b/tests/integration/controllers/comments/deleteComment.test.js
@@ -90,19 +90,20 @@ describe('delete comment controller', () => {
     });
 
     it('deletes the comment when author session hash matches', async () => {
+        const accessToken = randomAccessToken();
 
         const createCommentBody = {
             comment: 'Test delete comment controller',
             questionId: 10,
             user: {
-              accessToken: '8b1a5ca556d49fc46c169b2c94a058065d566f01bb208519cffd2d7419f4ff8cb4d63a060019e86354708c55766a60a2449edff151bb34681d4012699ebc3j65',
+              accessToken: accessToken,
             },
             isAnonymous: true,
         };
 
         const deleteCommentBody = {
           commentId: null,
-          accessToken: '8b1a5ca556d49fc46c169b2c94a058065d566f01bb208519cffd2d7419f4ff8cb4d63a060019e86354708c55766a60a2449edff151bb34681d4012699ebc3j65'
+          accessToken: accessToken
         };
 
         const createCommentResponse = await createComment(createCommentBody);
@@ -115,6 +116,9 @@ describe('delete comment controller', () => {
         deleteCommentBody.commentId = createCommentResponse.comment.id;
 
         const deleteCommentResponse = await deleteComment(deleteCommentBody);
+        if(!deleteCommentResponse.successMessage) {
+          console.log(deleteCommentResponse);
+        }
         expect(deleteCommentResponse).toBeDefined();
         expect(deleteCommentResponse.successMessage).toBeDefined();
         expect(deleteCommentResponse.successMessage).toBe('Comment was deleted successfully');


### PR DESCRIPTION
#### What does this PR do?
- Fixes (or attempt to fix) bug described in #82 
- I believe the bug was a concurrency issue with the generateMinMaxDates validation, so I added a mock for this function to validate that the comment is always on deletable range.

#### How should this be manually tested?
Run the tests locally, although it usually happened during Github Actions / PR


#### Any background context you want to provide?
- Ran Actions several times in this PR and didn't get the error again, but we should still keep an eye if it happens again and this were just false positives.

#### What are the relevant tickets?
Closes #82 
