### PR TITLE
chore(infrastructure): update terraform production vpc config

### DIFF
--- a/infrastructure/cloudbuild.yaml
+++ b/infrastructure/cloudbuild.yaml
@@ -29,3 +29,4 @@ steps:
         terraform init
         terraform workspace select $_DEPLOY_ENV  || terraform workspace new $_DEPLOY_ENV 
         terraform apply -auto-approve -var 'short_sha=$SHORT_SHA' -var-file='$_DEPLOY_ENV.tfvars'
+timeout: 1500s

--- a/infrastructure/cloudbuild.yaml
+++ b/infrastructure/cloudbuild.yaml
@@ -29,4 +29,3 @@ steps:
         terraform init
         terraform workspace select $_DEPLOY_ENV  || terraform workspace new $_DEPLOY_ENV 
         terraform apply -auto-approve -var 'short_sha=$SHORT_SHA' -var-file='$_DEPLOY_ENV.tfvars'
-timeout: 1500s

--- a/infrastructure/terraform/master.tfvars
+++ b/infrastructure/terraform/master.tfvars
@@ -1,5 +1,3 @@
-
-
 app_env         = "prod"
 cr_cpu_limit    = "2000m"
 cr_memory_limit = "512Mi"

--- a/infrastructure/terraform/modules/cloud_run/cloud_run.tf
+++ b/infrastructure/terraform/modules/cloud_run/cloud_run.tf
@@ -93,7 +93,7 @@ resource "google_cloud_run_service_iam_policy" "noauth" {
 
 resource "google_vpc_access_connector" "connector" {
   region         = var.region
-  name           = "${var.prefix}-connector"
+  name           = substr("${var.prefix}-connector", 0, 25)
   ip_cidr_range  = var.cidr_range
   network        = "default"
   max_throughput = 1000


### PR DESCRIPTION
#### What does this PR do?
- Some changes to Terraform files for the first produciton release
- Substr is needed in vpc connector since an error occurred with "wizeq-remix-prod-connector" as this excedeed the mas character limit. To not oveerride the existing "wizeq-remix-dev-connector" in develop, substr is used to only truncate when exceeding 25 characters
