### PR TITLE
chore: add release changelog github action

### DIFF
--- a/.github/workflows/release-config.json
+++ b/.github/workflows/release-config.json
@@ -1,0 +1,90 @@
+{
+  "categories": [
+    {
+      "title": "## 🚀 New Features",
+      "labels": ["feat"]
+    },
+    {
+      "title": "## 🐛 Fixes",
+      "labels": ["fix"]
+    },
+    {
+      "title": "## 🧪 Tests",
+      "labels": ["test"]
+    },
+    {
+        "title": "## 📦 Dependencies",
+        "labels": ["deps", "build"]
+    },
+    {
+      "title": "## 📖 Documentation",
+      "labels": ["docs"]
+    },
+    {
+      "title": "## 🧹 Chores",
+      "labels": ["chore"]
+    }
+  ],
+  "ignore_labels": [
+    "ignore"
+  ],
+  "sort": "ASC",
+  "template": "${{CHANGELOG}}\n\n<details>\n<summary>Uncategorized</summary>\n\n${{UNCATEGORIZED}}\n</details>",
+  "pr_template": "- ${{TITLE}}\n   - PR: #${{NUMBER}}",
+  "empty_template": "- no changes",
+  "label_extractor": [
+    {
+      "pattern": "^feat",
+      "on_property": "title",
+      "method": "match"
+    },
+    {
+      "pattern": "^test",
+      "on_property": "title",
+      "method": "match"
+    },
+    {
+      "pattern": "^build",
+      "on_property": "title",
+      "method": "match"
+    },
+    {
+      "pattern": "^fix",
+      "on_property": "title",
+      "method": "match"
+    },
+    {
+      "pattern": "^docs",
+      "on_property": "title",
+      "method": "match"
+    },
+    {
+      "pattern": "^doc",
+      "on_property": "title",
+      "method": "match"
+    },
+    {
+      "pattern": "^chore",
+      "on_property": "title",
+      "method": "match"
+    }
+  ],
+  "transformers": [
+    {
+      "pattern": "(\\w+)(\\()(.+)(\\)): (.+)\n(.+?[\\-\\*] )(.+)",
+      "target": "[$3] - $5\n   - $7"
+    },
+    {
+      "pattern": "(\\w+)(\\()(.+)(\\))(!): (.+)\n(.+?[\\-\\*] )(.+)",
+      "target": "[$3] BREAKING - $6\n   - $8"
+    },
+    {
+      "pattern": "(\\w+): (.+)\n(.+?[\\-\\*] )(.+)",
+      "target": "$2\n   - $4"
+    },
+    {
+      "pattern": "(\\w+)(!): (.+)\n(.+?[\\-\\*] )(.+)",
+      "target": "BREAKING - $3\n   - $5"
+    }
+  ]
+}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,33 @@
+name: 'Create Release Notes'
+on:
+  # push:
+  #   tags:
+  #     - 'v[0-9]+.[0-9]+.[0-9]+'
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  release:
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout master branch
+        uses: actions/checkout@v2.2.0
+        with:
+          ref: master
+      - name: Build Changelog
+        id: github_release
+        uses: mikepenz/release-changelog-builder-action@v2.7.0
+        with:
+          configuration: ".github/workflows/release-config.json"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create Release
+        uses: actions/create-release@v1
+
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          body: ${{steps.github_release.outputs.changelog}}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,10 +1,8 @@
 name: 'Create Release Notes'
 on:
-  # push:
-  #   tags:
-  #     - 'v[0-9]+.[0-9]+.[0-9]+'
-  pull_request:
-    branches: [ "master" ]
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   release:


### PR DESCRIPTION
#### What does this PR do?
- Adds Github Action trigger to automatically create release notes using latest semantic commits with tags, done in the same way as the https://github.com/wizeline/anubis project.
- Merging and creating first release should Close #94 

