### PR TITLE
fix: add creation of user when first logging in

### DIFF
--- a/app/auth.server.js
+++ b/app/auth.server.js
@@ -1,7 +1,7 @@
 import { Authenticator } from "remix-auth";
 import { Auth0Strategy } from "remix-auth-auth0";
 import { sessionStorage } from "~/session.server";
-import { findUser } from "~/controllers/users/find";
+import { findOrCreateUser } from "~/controllers/users/find";
 
 const callbackURL = `${process.env.BASE_URL}/auth/auth0/callback`;
 const clientID = process.env.AUTH0_CLIENT_ID || "AUTH0_CLIENT_ID must be set";
@@ -20,7 +20,17 @@ const strategyConfig =  {
 let auth0Strategy = new Auth0Strategy(strategyConfig,
   async ({ accessToken, refreshToken, extraParams, profile }) => {
     try {
-      const user = await findUser(profile.emails[0].value)
+
+      const fullName = `${profile.name.givenName} ${profile.name.familyName}`;
+      const email = profile.emails.length > 0 ? profile.emails[0].value : undefined;
+      const profilePic = profile.photos.length > 0 ? profile.photos[0].value : undefined;
+
+      const user = await findOrCreateUser({
+        full_name: fullName,
+        email: email,
+        profile_picture: profilePic,
+      });
+
       return {
         ...user,
         accessToken,

--- a/app/controllers/users/find.js
+++ b/app/controllers/users/find.js
@@ -8,3 +8,25 @@ export const findUser = async (email) => {
   });
   return user;
 }
+
+export const findOrCreateUser = async ({email, profile_picture, full_name}) => {
+  const user = await db.users.findUnique({
+    where: {
+      email,
+    }
+  });
+
+  if (!user) {
+    const createdUser = await db.users.create({
+      data: {
+        email: email,
+        profile_picture: profile_picture,
+        full_name: full_name,
+      }
+    });
+
+    return createdUser;
+  }
+
+  return user;
+}


### PR DESCRIPTION
#### What does this PR do?
- Adds logic to create user when authenticating and email is not found on database (for new users)
- Adds tests to validate this

#### Where should the reviewer start?
- Running integration tests

#### How should this be manually tested?
1. To test manually, you need to disable your local database constraints by running the SQL: `SET FOREIGN_KEY_CHECKS=0;` ( do not forget to turn it back on when finished).
2. Change your user email to another temporal value
3. Log off and login in your local environment, a new user should be created with your full name, email, and profile picture
4. Delete this and enable constraint check again 

#### What are the relevant tickets?
Closes #122 
