### PR TITLE
fix: added scroll and prevent overflow

### DIFF
--- a/app/components/Modals/AssignAnswerModal/AssignAnswerModal.Styled.jsx
+++ b/app/components/Modals/AssignAnswerModal/AssignAnswerModal.Styled.jsx
@@ -34,7 +34,6 @@ export const AssignModalDialog = styled.div`
     width: 100%;
     display: block;
     max-height: calc(100vh - 150px);
-    overflow-y: visible;
 
     @media (max-width: 768px) {
         max-height: 100%;
@@ -101,6 +100,11 @@ export const SelectContainer = styled.div`
     padding-left: 0;
     position: relative;
     max-width: 100%;
+
+    & ul {
+        max-height:300px;
+        overflow-y:scroll;
+    }
 `;
 
 export const CustDropDownButton = styled(DropdownButton)`


### PR DESCRIPTION
#### What does this PR do?
This fix will prevent the departments not being displayed as a scroll was added. 

#### Where should the reviewer start?
app/components/Modals/AssignAnswerModal/AssignAnswerModal.Styled.jsx

#### How should this be manually tested?

1. As an admin, on the landing page  click on any question displayed
2. Click on the reassign option of the question
3. Click on the select department dropdown 
4. Verify that you are able to scroll thought the options displayed. 



#### What are the relevant tickets?
Closes #157 

#### Screenshots
<img width="928" alt="image" src="https://user-images.githubusercontent.com/97201781/211375745-7181dd1b-0c2b-405e-9c8d-d642a3ae7ee7.png">


