### PR TITLE
add is_public in the Questions table. 

### DIFF
--- a/prisma/migrations/20230118160544_add_question_is_public/migration.sql
+++ b/prisma/migrations/20230118160544_add_question_is_public/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `Questions` ADD COLUMN `is_public` BOOLEAN NOT NULL DEFAULT true;


### PR DESCRIPTION
#### What does this PR do?
- Create a migration to add a new column `is_public `

#### How should this be manually tested?
1. run the command `npx prisma migrate dev`
2. verify that you can see the new column in the database
3. verify that you can see the new column in the  Prisma schema using the command `npx prisma db`

#### What are the relevant tickets?
Closes #161 

#### Screenshots
<img width="1568" alt="Screen Shot 2023-01-18 at 11 38 00" src="https://user-images.githubusercontent.com/97203617/213254256-88871376-bd10-44b2-a497-7432a81b44cc.png">
