### PR TITLE
feat: new anonymous question creation logic

### DIFF
--- a/app/components/Notifications/Notifications.jsx
+++ b/app/components/Notifications/Notifications.jsx
@@ -1,16 +1,30 @@
 import { useActionData } from '@remix-run/react';
 import React, { useEffect } from 'react';
 import { ToastContainer, toast } from 'react-toastify';
-import { DEFAULT_TOAST_CONFIG } from 'app/utils/constants';
+import { DEFAULT_TOAST_CONFIG, QUESTION_CREATED_TOAST_CONFIG } from 'app/utils/constants';
 import useGlobalSuccessMessage from 'app/utils/hooks/useGlobalSuccessMessage';
 
 function Notifications() {
   const globalSuccess = useGlobalSuccessMessage();
   const data = useActionData();
 
+  const successAnonMessage = (message, questionUrl) => (
+    <div>
+      <p>{message}</p>
+      <a href={questionUrl}>
+        {questionUrl}
+      </a>
+    </div>
+  );
+
   useEffect(() => {
     if (globalSuccess) {
-      toast.success(globalSuccess, DEFAULT_TOAST_CONFIG);
+      const { message, questionUrl } = globalSuccess;
+      if (questionUrl) {
+        toast.info(successAnonMessage(message, questionUrl), QUESTION_CREATED_TOAST_CONFIG);
+      } else {
+        toast.info(message, QUESTION_CREATED_TOAST_CONFIG);
+      }
     }
     if (!data) return;
 

--- a/app/components/QuestionForm/QuestionForm.jsx
+++ b/app/components/QuestionForm/QuestionForm.jsx
@@ -22,6 +22,7 @@ import {
   LOCATION_WARNING,
   NO_DEPARTMENT_SELECTED_ID,
   NOT_ASSIGNED_DEPARTMENT_ID,
+  ANON_QUESTION_REQUIRES_ASSIGNEE,
 } from 'app/utils/constants';
 import * as Styled from 'app/components/QuestionForm/QuestionForm.Styled';
 import Switch from 'app/components/Switch';
@@ -228,6 +229,8 @@ function QuestionForm({
     const {
       assignedDepartment,
       inputValue,
+      isAnonymous,
+      assignedEmployee,
     } = state;
 
     const sanitizedInput = deleteNoMarkupFormatHTML(inputValue.trim());
@@ -247,6 +250,11 @@ function QuestionForm({
     if (locations.length === 0) {
       askBtbEnabled = false;
       tooltipMessage = NO_LOCATIONS_AVAILABLE_TOOLTIP_MESSAGE;
+    }
+
+    if (isAnonymous && !assignedEmployee) {
+      askBtbEnabled = false;
+      tooltipMessage = ANON_QUESTION_REQUIRES_ASSIGNEE;
     }
 
     return {

--- a/app/controllers/employees/list.js
+++ b/app/controllers/employees/list.js
@@ -2,16 +2,22 @@ import { db } from 'app/utils/db.server';
 
 const listEmployees = async (id) => {
   const idValue = parseInt(id, 10);
-  const relations = await db.EmployeesDepartments.findMany({
+  const employees = await db.EmployeesDepartments.findMany({
     where: {
       department_id: idValue,
     },
     distinct: ['email'],
-    include: {
-      users: true,
+    select: {
+      users: {
+        select: {
+          full_name: true,
+          employee_id: true,
+        },
+      },
     },
   });
-  return relations.map((rel) => ({ name: rel.users.full_name, id: rel.employee_id }));
+  const filtered = employees.filter((employee) => employee.users !== null);
+  return filtered.map((employee) => employee.users);
 };
 
 export default listEmployees;

--- a/app/controllers/questions/create.js
+++ b/app/controllers/questions/create.js
@@ -29,8 +29,10 @@ const createQuestion = async (body) => {
     data: {
       ...rest,
       question: sanitizeHTML(value.question),
+      is_public: !((value.is_anonymous && value.is_anonymous === true)),
     },
   });
+  let successMessage;
 
   if (value.is_anonymous) {
     const sessionHash = generateSessionIdHash(accessToken, created.question_id);
@@ -49,7 +51,11 @@ const createQuestion = async (body) => {
         employee_id: created.assigned_to_employee_id,
       },
     });
-
+    const questionDetailUrl = getQuestionDetailUrl(created.question_id);
+    successMessage = {
+      message: 'The anonymous question has been created succesfully!\n\nPlease save the attached link for followup on answers: ',
+      questionUrl: questionDetailUrl,
+    };
     await sendEmail({
       to: userAssigned.email,
       subject: EMAILS.anonymousQuestionAssigned.subject,
@@ -65,10 +71,13 @@ const createQuestion = async (body) => {
       questionBody: stripNewLines(truncate(value.question), SLACK_QUESTION_LIMIT),
       questionId: created.question_id,
     });
+    successMessage = {
+      message: 'The question has been created succesfully!',
+    };
   }
 
   return {
-    successMessage: 'The question has been created succesfully!',
+    successMessage,
     question: created,
   };
 };

--- a/app/routes/employees/getByDeparment/$id.js
+++ b/app/routes/employees/getByDeparment/$id.js
@@ -5,8 +5,11 @@ export const loader = async (data) => {
   if (params.id === -1 || params.id === 'undefined') {
     return [];
   }
-  const employess = await listEmployees(params.id);
-  return employess;
+  const employees = await listEmployees(params.id);
+  return employees.map((employee) => ({
+    name: employee.full_name,
+    id: employee.employee_id,
+  }));
 };
 
 export default loader;

--- a/app/styles/CreateQuestion.Styled.jsx
+++ b/app/styles/CreateQuestion.Styled.jsx
@@ -56,10 +56,6 @@ export const Recommendations = styled.div`
       font-size: 14px;
       margin-bottom: 15px;
     }
-    &:nth-child(2),
-    &:nth-child(3),
-    &:nth-child(4) {
-      margin-bottom: 10px;
-    }
+    margin-bottom: 10px;   
   }
 `;

--- a/app/utils/backend/validators/question.js
+++ b/app/utils/backend/validators/question.js
@@ -13,7 +13,11 @@ export const createQuestionSchema = Joi.object().keys({
   location: Joi.string().required(),
   created_by_employee_id: Joi.number().integer().min(1).allow(null),
   assigned_department: Joi.number().integer().min(1).allow(null),
-  assigned_to_employee_id: Joi.number().integer().min(1).allow(null),
+  assigned_to_employee_id: Joi.number().integer().min(1).when('is_anonymous', {
+    is: false,
+    then: Joi.optional(),
+    otherwise: Joi.required(),
+  }),
 });
 
 export const modifyQuestionPinStatusParams = Joi.object().keys({

--- a/app/utils/constants.js
+++ b/app/utils/constants.js
@@ -334,6 +334,9 @@ export const RECOMMENDATIONS_QUESTION = [
   'Do not demean or degrade others because of their gender, race, age, religion, etc.',
   'Avoid posting questions that include sexually explicit comments, hate speech, prejudicial remarks, and profanity.',
   'Do not mock other members, their comments, profiles, threads, or experiences. Remember, what is funny for you may be offensive to others.',
+  'For anonymous questions, you have to select a specific employee according to the department selected.',
+  'Anonymous questions will not appear on the home page until an admin has published it.',
+  'Although the question has not been published, you can the link of your question to followup on answers.',
 ];
 
 // Recurring error messages

--- a/app/utils/constants.js
+++ b/app/utils/constants.js
@@ -269,6 +269,7 @@ export const NO_COLLABORATOR_SELECTED_TOOLTIP_MESSAGE = 'Select a collaborator';
 export const MIN_CHARS_QUESTION_INPUT_TOOLTIP_MESSAGE = inputPlaceholder(MINIMUM_QUESTION_LENGTH);
 export const DEFAULT_MESSAGE_END_QUESTION_INPUT_TOOLTIP = 'to ask a question.';
 export const NO_LOCATIONS_AVAILABLE_TOOLTIP_MESSAGE = 'There are no locations';
+export const ANON_QUESTION_REQUIRES_ASSIGNEE = 'Select an assigned employee';
 
 // Sockets & Reactivity
 export const FAKE_SOCKET = {

--- a/app/utils/constants.js
+++ b/app/utils/constants.js
@@ -318,6 +318,16 @@ export const DEFAULT_TOAST_CONFIG = {
   progress: undefined,
 };
 
+export const QUESTION_CREATED_TOAST_CONFIG = {
+  position: 'top-right',
+  autoClose: false,
+  hideProgressBar: false,
+  closeOnClick: false,
+  pauseOnHover: true,
+  draggable: false,
+  progress: undefined,
+};
+
 // Things to Keep in Mind
 export const RECOMMENDATIONS_QUESTION = [
   'Strive for constructive open communication. Avoid vagueness.',

--- a/tests/fixtures/employeeDepartment.json
+++ b/tests/fixtures/employeeDepartment.json
@@ -1,0 +1,12 @@
+[
+  {
+    "employee_id": 1,
+    "department_id": 1,
+    "email": "testmail1@mail.com"
+  },
+  {
+    "employee_id": 2,
+    "department_id": 1,
+    "email": "testmail2@mail.com"
+  }
+]

--- a/tests/initTestDb.js
+++ b/tests/initTestDb.js
@@ -10,6 +10,7 @@ import answersFixture from './fixtures/answers.json';
 import votesFixture from './fixtures/votes.json';
 import npsFixture from './fixtures/nps.json';
 import commentVotes from './fixtures/commentVotes.json';
+import employeeDepartmentFixture from './fixtures/employeeDepartment.json';
 
 const initTestDb = async () => {
   await db.$connect();
@@ -92,6 +93,12 @@ const initTestDb = async () => {
   // Create CommentVotes
   await db.CommentVote.createMany({
     data: commentVotes,
+    skipDuplicates: true,
+  });
+
+  // Create EmployeeDepartment
+  await db.EmployeesDepartments.createMany({
+    data: employeeDepartmentFixture,
     skipDuplicates: true,
   });
 };

--- a/tests/integration/controllers/employees/getEmployeesByDepartment.test.js
+++ b/tests/integration/controllers/employees/getEmployeesByDepartment.test.js
@@ -1,0 +1,28 @@
+import listEmployees from 'app/controllers/employees/list';
+
+describe('list employees by department controller', () => {
+  it('returns list of employees if valid department id passed', async () => {
+    const expected = [
+      {
+        employee_id: 1,
+        full_name: 'Patrick Shu',
+      },
+      {
+        employee_id: 2,
+        full_name: 'John Doe',
+      },
+    ];
+
+    const employees = await listEmployees(1);
+    expect(employees).toBeDefined();
+    expect(employees).toEqual(expected);
+  });
+
+  it('returns empty list employees if department has no employees', async () => {
+    const expected = [];
+
+    const employees = await listEmployees(99);
+    expect(employees).toBeDefined();
+    expect(employees).toEqual(expected);
+  });
+});

--- a/tests/integration/controllers/questions/createQuestion.test.js
+++ b/tests/integration/controllers/questions/createQuestion.test.js
@@ -12,6 +12,7 @@ describe('createQuestion', () => {
   const emailHandlerSpy = jest.spyOn(emailHandler, 'sendEmail').mockImplementation();
 
   afterEach(() => {
+    dbCreateSpy.mockClear();
     slackSpy.mockClear();
     emailHandlerSpy.mockClear();
   });
@@ -55,6 +56,27 @@ describe('createQuestion', () => {
     expect(dbUpdateSpy).toHaveBeenCalledTimes(0);
 
     expect(slackSpy).toHaveBeenCalled();
+    expect(emailHandlerSpy).toHaveBeenCalledTimes(0);
+  });
+
+  it('require assigned employee on anonymous question', async () => {
+    const question = {
+      question: '_This_ is a **sample** ~~question~~',
+      created_by_employee_id: 1,
+      accessToken: randomAccessToken(),
+      is_anonymous: true,
+      assigned_department: 3,
+      location: 'BNK',
+    };
+
+    const response = await createQuestion(question);
+
+    expect(response).toBeDefined();
+    expect(response.errors).toBeDefined();
+    expect(response.successMessage).toBeUndefined();
+    expect(response.question).toBeUndefined();
+
+    expect(dbCreateSpy).toHaveBeenCalledTimes(0);
     expect(emailHandlerSpy).toHaveBeenCalledTimes(0);
   });
 

--- a/tests/integration/controllers/questions/createQuestion.test.js
+++ b/tests/integration/controllers/questions/createQuestion.test.js
@@ -50,6 +50,7 @@ describe('createQuestion', () => {
     expect(response).toBeDefined();
     expect(response.successMessage).toBeDefined();
     expect(response.question).toBeDefined();
+    expect(response.question.is_public).toBe(true);
     expect(response.question.user_hash).toBe('');
 
     expect(dbCreateSpy).toHaveBeenCalled();
@@ -96,6 +97,7 @@ describe('createQuestion', () => {
     expect(response).toBeDefined();
     expect(response.successMessage).toBeDefined();
     expect(response.question).toBeDefined();
+    expect(response.question.is_public).toBe(false);
     expect(response.question.user_hash).not.toBe('');
 
     expect(dbCreateSpy).toHaveBeenCalled();

--- a/tests/tearDownDb.js
+++ b/tests/tearDownDb.js
@@ -4,6 +4,7 @@ const tearDownDb = async () => {
   await db.$connect();
 
   // Delete in reverse order
+  await db.EmployeesDepartments.deleteMany();
   await db.Nps.deleteMany();
   await db.Votes.deleteMany();
   await db.Answers.deleteMany();


### PR DESCRIPTION
#### What does this PR do?
- Changes anonymous questions creation to change is_public field to false
- Adds validation/constraint on submit button to enforce an assigned employee when anonymous is toggled on
- Modifies redirect rule to go to question detail instead of home only when its an anonymous question
- Changes globalSuccess toast notification to add the question detail url. This toast does not autoclose.But suggestions to make this feedbnack more visible and better is still appreciated
- Refactors listEmployees controller to fix a bug where some empty user entries would cause an error given they do not have the full_name property. Empty/null entries are now skipped.

#### Where should the reviewer start?
Going to the new controller changes mostly

#### How should this be manually tested?
1. Go to question creation and toggle anonymous question on
2. Validate that the submit button is disabled until an assigned employee is set
3. Create the question 
4. Verify that you are redirected to the question detail
5. Verify that a toast message is shown (and does not autclose) with the question detail url
6. Verify that the is_public field for the question is false (you can check this by seeing if the new icon introducced in #161 appears
7. Extra: Verify that the normal flow for non-anonymous question is intact

#### Any background context you want to provide?
None

#### What are the relevant tickets?
Closes #143 
Closes #172 

#### Screenshots


https://user-images.githubusercontent.com/38927620/215862589-4f564658-b780-4907-a0e0-ed0a3a88fdc9.mov


