### PR TITLE
fix: refactor assigned_employee_id on question creation from null to undefined

### DIFF
--- a/app/components/QuestionForm/QuestionForm.jsx
+++ b/app/components/QuestionForm/QuestionForm.jsx
@@ -59,7 +59,7 @@ function QuestionForm({
     fullLocation: '',
     isShowPreview: false,
     askBtbEnabled: false,
-    assignedEmployee: null,
+    assignedEmployee: undefined,
     employeesByDepartment: [],
   };
 
@@ -86,7 +86,7 @@ function QuestionForm({
 
         setState({
           ...state,
-          assignedEmployee: null,
+          assignedEmployee: undefined,
         });
       }
     };
@@ -113,13 +113,12 @@ function QuestionForm({
       location, isAnonymous, inputValue, assignedDepartment,
     } = state;
     setState({ ...state, showSubmitWithModal: false });
-
     const question = {
       isAnonymous,
       question: deleteNoMarkupFormatHTML(inputValue.trim()),
       location: location === NONE_LOCATION ? DEFAULT_LOCATION : location,
       assignedDepartment: assignedDepartment.department_id || 'wizeq',
-      assigned_to_employee_id: state.assignedEmployee ? state.assignedEmployee.id : null,
+      assigned_to_employee_id: state.assignedEmployee ? state.assignedEmployee.id : undefined,
     };
 
     try {

--- a/app/routes/questions/new.jsx
+++ b/app/routes/questions/new.jsx
@@ -28,10 +28,12 @@ export const loader = async ({ request }) => {
 
 export const action = async ({ request }) => {
   const formData = await request.formData();
+  // values passed as strings
   const form = Object.fromEntries(formData.entries());
+  const { assignedDepartment, assigned_to_employee_id: assignedEmployeeId } = form;
   const user = await getAuthenticatedUser(request);
-  const parsedDepartment = parseInt(form.assignedDepartment, 10);
-  const assignedEmployeeValue = parseInt(form.assigned_to_employee_id, 10);
+  const parsedDepartment = parseInt(assignedDepartment, 10);
+  const assignedEmployeeValue = assignedEmployeeId !== 'undefined' ? parseInt(assignedEmployeeId, 10) : undefined;
   const isAnonymous = form.isAnonymous === 'true';
 
   const payload = {


### PR DESCRIPTION
#### What does this PR do?
- Updates question creation logic client side to send the assigned_employee_id as undefined instead of null when not selecting any. Will fix question creation error introducced in #177.

#### How should this be manually tested?
1. Create both a normal question (without an assigned employee) and an anonymous question with someone assigned. 
2. Verify the question is created succesfully

#### Any background context you want to provide?
Problem is Joi validation that takes null objects and asserts it, for these cases undefined is what we need.

#### What are the relevant tickets?
Closes #179 
