### PR TITLE
feat: send slack notification on question published

### DIFF
--- a/app/controllers/questions/publishQuestion.js
+++ b/app/controllers/questions/publishQuestion.js
@@ -1,5 +1,8 @@
 import { db } from 'app/utils/db.server';
 import { PIN_QUESTION_ERROR_MESSAGE, INVALID_PARAMS_FOR_OPERATION_ERROR_MESSAGE, PUBLISH_QUESTION_ERROR_MESSAE } from 'app/utils/constants';
+import slack from 'app/utils/backend/slackNotifications';
+import { stripNewLines, truncate } from 'app/utils/backend/stringUtils';
+import { SLACK_QUESTION_LIMIT } from 'app/utils/backend/slackConstants';
 
 const publishQuestion = async (questionId) => {
   if (typeof questionId !== 'number'
@@ -16,6 +19,11 @@ const publishQuestion = async (questionId) => {
     const updatedQuestion = await db.Questions.update({
       where: { question_id: questionId },
       data: { is_public: true },
+    });
+
+    await slack.createQuestionNotification({
+      questionBody: stripNewLines(truncate(updatedQuestion.question), SLACK_QUESTION_LIMIT),
+      questionId: updatedQuestion.question_id,
     });
 
     return {

--- a/tests/integration/controllers/questions/publishQuestion.test.js
+++ b/tests/integration/controllers/questions/publishQuestion.test.js
@@ -1,12 +1,20 @@
 import publishQuestion from 'app/controllers/questions/publishQuestion';
 import randomAccessToken from 'tests/utils';
 import createQuestion from 'app/controllers/questions/create';
+import slack from 'app/utils/backend/slackNotifications';
+
 import {
   PIN_QUESTION_ERROR_MESSAGE,
   INVALID_PARAMS_FOR_OPERATION_ERROR_MESSAGE,
 } from 'app/utils/constants';
 
 describe('question controller: publish question', () => {
+  const slackSpy = jest.spyOn(slack, 'createQuestionNotification').mockImplementation();
+
+  afterEach(() => {
+    slackSpy.mockClear();
+  });
+
   it('return an error when provied no parameters', async () => {
     const response = await publishQuestion();
 
@@ -45,7 +53,7 @@ describe('question controller: publish question', () => {
     expect(response.question).toBeUndefined();
   });
 
-  it('return a success messaje', async () => {
+  it('makes question public with valid parameters', async () => {
     // create a anonymous questions
     const anonymousQuestion = {
       question: 'This is an example of anonymous question',
@@ -70,5 +78,8 @@ describe('question controller: publish question', () => {
     expect(publishQuestionResponse.error).toBeUndefined();
     expect(publishQuestionResponse.successMessage).toBe('The question has been published');
     expect(publishQuestionResponse.question.is_public).toBe(true);
+
+    // Send slack notification
+    expect(slackSpy).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
#### What does this PR do?
- Sends slack notification when publishQuestion controller is called.
#### Where should the reviewer start?
- See addition to the controller

#### How should this be manually tested?
1. Add the slack credentials to your .env (DM me on Slack if you want me to share it)
2. Publish a question
3. Verify that a notification is sent to #wizeq-dev
4. ⚠️ REMOVE the credentials from .env to avoid unintended messages sent

Additionally this is tested with the integration tests and will be test-able in develop env

#### What are the relevant tickets?
Closes #187 
