### PR TITLE
fix: enable mobile navbar logout option

### DIFF
--- a/app/components/UserControls/UserControls.jsx
+++ b/app/components/UserControls/UserControls.jsx
@@ -52,12 +52,12 @@ function UserControls(props) {
           />
         </ButtonToolbar>
       </Styled.NavLi>
-      {/* <Styled.XSNavItem
+      <Styled.XSNavItem
         eventKey={2}
         onClick={handleLogoutClick}
       >
         Logout
-      </Styled.XSNavItem> */}
+      </Styled.XSNavItem>
       <LogoutConfirmationModal
         show={showLogoutModal}
         onClose={handleCancelLogoutClick}


### PR DESCRIPTION
#### What does this PR do?
- Uncomments navbar option for mobile, probably I commented it during the app Remix transition for testing and missed uncommenting, sorry about this.

#### Where should the reviewer start?
Open any page on mobile view

#### How should this be manually tested?
1. Open navbar option
2. Verify you can logout with the navbar button

#### What are the relevant tickets?
Closes #148 
