### PR TITLE
feat: send email to created question department manager

### DIFF
--- a/app/config/emails.json
+++ b/app/config/emails.json
@@ -1,0 +1,4 @@
+{
+  "defaultManagerEmail": "wizeq@wizeline.com",
+  "defaultManagerName": "Wizeliner"
+}

--- a/app/config/flags.json
+++ b/app/config/flags.json
@@ -1,3 +1,5 @@
 {
-  "requireEmployeeAssigned": false
+  "requireEmployeeAssigned": false,
+  "sendEmailToManagerOnQuestionCreation": true,
+  "sendSlackOnQuestionCreation": true
 }

--- a/app/utils/backend/emails/emailConstants.js
+++ b/app/utils/backend/emails/emailConstants.js
@@ -2,7 +2,11 @@ export const EMAIL_SUBJECT_PREFIX = 'Wizeline Questions - ';
 
 export const EMAILS = {
   anonymousQuestionAssigned: {
-    subject: 'New question assigned to you',
+    subject: 'A new anonymous question assigned to you',
     template: 'anonymousQuestionAssigned',
+  },
+  publicQuestionAssigned: {
+    subject: 'A new question assigned to you',
+    template: 'publicQuestionAssigned',
   },
 };

--- a/app/utils/backend/emails/templates/views/publicQuestionAssigned.hbs
+++ b/app/utils/backend/emails/templates/views/publicQuestionAssigned.hbs
@@ -1,0 +1,4 @@
+{{> greeting}}
+A user asked the following question and suggested you to answer it:
+{{> questionPreview}}
+To answer the question, <a href="{{question_url}}"> click here </a>

--- a/tests/fixtures/departments.json
+++ b/tests/fixtures/departments.json
@@ -12,7 +12,8 @@
   {
     "department_id": 3,
     "name": "Business Operations",
-    "is_active": 1
+    "is_active": 1,
+    "manager_employee_id": 1
   },
   {
     "department_id": 4,


### PR DESCRIPTION
#### What does this PR do?
- Refactors createQuestion controller to send slack and email (to department manager) on both anonymous and public questions.
- Adds feature flag to activate/deactivate sending email and slack on question creating through config
- Adds template for questionAssigned for public questions (its basically almost a copy of the anonymous one for now, but we could make it different)

#### Where should the reviewer start?
- If you want to test the emails and slacks locally, send me a Slack so I can give you the .env credentials (we should be careful with these though). Otherwise we can test on develop

#### What are the relevant tickets?
(Link to issues, related PR, JIRA issues, etc.)
Closes #203 

Public
<img width="1028" alt="image" src="https://user-images.githubusercontent.com/38927620/234940857-321bae72-3300-4154-ae20-c58ce7a80ca1.png">

Anon
<img width="995" alt="Screenshot 2023-04-27 at 10 23 11" src="https://user-images.githubusercontent.com/38927620/234940995-e9b16d26-1eb7-44b5-a1c2-7a53b0d79231.png">

