### PR TITLE
feat: add alternate/substitute manager to the deparments

### DIFF
--- a/app/components/AdminDepartments/AdminDepartments.jsx
+++ b/app/components/AdminDepartments/AdminDepartments.jsx
@@ -106,6 +106,11 @@ function AdminDepartments({
     });
   };
 
+  const setManager = (deparment) => {
+    const { ManagerDepartmet, AlternateManager } = deparment;
+    return `${ManagerDepartmet.full_name} ${AlternateManager ? `/ ${AlternateManager.full_name}` : ''}`;
+  };
+
   return (
     <div>
       <Styled.TableContainer>
@@ -136,7 +141,7 @@ function AdminDepartments({
                 <td>{deparment.name}</td>
                 <td>
                   {' '}
-                  {(deparment.ManagerDepartmet && deparment.ManagerDepartmet.full_name !== undefined) ? deparment.ManagerDepartmet.full_name : ''}
+                  {(deparment.ManagerDepartmet && deparment.ManagerDepartmet.full_name !== undefined) ? setManager(deparment) : ''}
                   {' '}
                 </td>
                 <td>

--- a/app/components/Modals/EditDeparmentModal/EditDepartmentModal.jsx
+++ b/app/components/Modals/EditDeparmentModal/EditDepartmentModal.jsx
@@ -15,24 +15,26 @@ function EditDepartmentModal({ department, onClose }) {
   const fetcher = useFetcher();
   const submit = useSubmit();
   const [currentUser, setCurrentUser] = useState({});
+  const [currentSubstitute, setCurrentSubstitute] = useState({});
   const [showDropdown, setShowDropdown] = useState(false);
+  const [showSubstitute, setShowSubstitute] = useState(false);
 
   const {
-    department_id, name, is_active, ManagerDepartmet,
+    department_id, name, is_active, ManagerDepartmet, AlternateManager,
   } = department;
 
   useEffect(() => {
     if (ManagerDepartmet && ManagerDepartmet.full_name !== undefined) {
-      const element = document.getElementById('search-id');
-      element.value = ManagerDepartmet.full_name;
+      const managerInput = document.getElementById('search-id');
+      managerInput.value = ManagerDepartmet.full_name;
+      setCurrentUser(ManagerDepartmet);
+    }
+    if (AlternateManager && AlternateManager.full_name !== undefined) {
+      const substituteInput = document.getElementById('search-substitute');
+      substituteInput.value = AlternateManager.full_name;
+      setCurrentSubstitute(AlternateManager);
     }
   }, []);
-
-  useEffect(() => {
-    if (fetcher.data && fetcher.data.searchUsers !== undefined) {
-      setShowDropdown(fetcher.data.searchUsers.length > 0);
-    }
-  }, [fetcher.data]);
 
   const sendQuery = (searchValue) => {
     fetcher.load(`/?userSearch=${searchValue}`);
@@ -41,15 +43,36 @@ function EditDepartmentModal({ department, onClose }) {
   const delayedQuery = useCallback(debounce((value) => sendQuery(value), 400), []);
 
   const onChange = (e) => {
-    setShowDropdown(e.target.value !== '');
+    if (e.target.id === 'search-id') setShowDropdown(e.target.value !== '');
+    if (e.target.id === 'search-substitute') setShowSubstitute(e.target.value !== '');
     delayedQuery(e.target.value);
   };
 
-  const onHandlerClick = (value) => {
-    const element = document.getElementById('search-id');
-    element.value = value.full_name;
-    setCurrentUser(value);
-    setShowDropdown(false);
+  const onDropdownClick = (elementId, user) => {
+    const element = document.getElementById(elementId);
+    element.value = user.full_name;
+    switch (elementId) {
+      case 'search-id':
+        setCurrentUser(user);
+        setShowDropdown(false);
+        break;
+      case 'search-substitute':
+        setCurrentSubstitute(user);
+        setShowSubstitute(false);
+        break;
+      default:
+        setShowDropdown(false);
+        setShowSubstitute(false);
+        break;
+    }
+  };
+
+  const onHandlerClick = (user) => {
+    onDropdownClick('search-id', user);
+  };
+
+  const onHandlerClickSubstitute = (user) => {
+    onDropdownClick('search-substitute', user);
   };
 
   const onSubmit = (e) => {
@@ -60,6 +83,7 @@ function EditDepartmentModal({ department, onClose }) {
     data.set('department_id', department_id);
     data.set('name', name);
     data.set('ManagerDepartmet', JSON.stringify(currentUser));
+    data.set('AlternateManager', JSON.stringify(currentSubstitute));
 
     submit(data, { method: 'post', action: '/admin', replace: true });
 
@@ -90,7 +114,7 @@ function EditDepartmentModal({ department, onClose }) {
               </S.TableRow>
               <S.TableRow>
                 <li>
-                  <b>User:</b>
+                  <b>Manager:</b>
                   {' '}
                 </li>
                 <li>
@@ -101,6 +125,22 @@ function EditDepartmentModal({ department, onClose }) {
                     data={buildData()}
                     showDropdown={showDropdown}
                     onDropdownClick={onHandlerClick}
+                  />
+                </li>
+              </S.TableRow>
+              <S.TableRow>
+                <li>
+                  <b>Substitute : (manager)</b>
+                  {' '}
+                </li>
+                <li>
+                  <SearchDropdown
+                    keyValue="full_name"
+                    inputId="search-substitute"
+                    onChange={(e) => { onChange(e); }}
+                    data={buildData()}
+                    showDropdown={showSubstitute}
+                    onDropdownClick={onHandlerClickSubstitute}
                   />
                 </li>
               </S.TableRow>
@@ -126,6 +166,9 @@ EditDepartmentModal.propTypes = {
         full_name: PropTypes.string,
       },
     ),
+    AlternateManager: PropTypes.shape({
+      full_name: PropTypes.string,
+    }),
   }),
   onClose: PropTypes.func.isRequired,
 
@@ -137,6 +180,9 @@ EditDepartmentModal.defaultProps = {
     name: '',
     is_active: true,
     ManagerDepartmet: {
+      full_name: '',
+    },
+    AlternateManager: {
       full_name: '',
     },
   },

--- a/app/components/Modals/EditDeparmentModal/EditDepartmentModal.jsx
+++ b/app/components/Modals/EditDeparmentModal/EditDepartmentModal.jsx
@@ -43,6 +43,11 @@ function EditDepartmentModal({ department, onClose }) {
   const delayedQuery = useCallback(debounce((value) => sendQuery(value), 400), []);
 
   const onChange = (e) => {
+    if (e.target.value === '') {
+      if (e.target.id === 'search-id') setCurrentUser({});
+      if (e.target.id === 'search-substitute') setCurrentSubstitute({});
+      return;
+    }
     if (e.target.id === 'search-id') setShowDropdown(e.target.value !== '');
     if (e.target.id === 'search-substitute') setShowSubstitute(e.target.value !== '');
     delayedQuery(e.target.value);

--- a/app/controllers/departments/list.js
+++ b/app/controllers/departments/list.js
@@ -49,7 +49,7 @@ const listDepartments = async (params) => {
     where: buildWhere(search),
     take: calLimit(allPages, count, limit),
     skip: calOffset(allPages, offset, limit, totalPages),
-    include: { ManagerDepartmet: true },
+    include: { ManagerDepartmet: true, AlternateManager: true },
   });
   return { departments, totalPages };
 };

--- a/app/controllers/departments/update.js
+++ b/app/controllers/departments/update.js
@@ -22,8 +22,10 @@ const updateDepartement = async (params) => {
     data: {
       name,
       is_active,
-      manager_employee_id: ManagerDepartmet ? ManagerDepartmet.employee_id : null,
-      alternate_manager_id: SubstituteManager ? SubstituteManager.employee_id : null,
+      manager_employee_id: (ManagerDepartmet && ManagerDepartmet.employee_id !== undefined)
+        ? ManagerDepartmet.employee_id : null,
+      alternate_manager_id: (SubstituteManager && SubstituteManager.employee_id !== undefined)
+        ? SubstituteManager.employee_id : null,
     },
   });
 

--- a/app/controllers/departments/update.js
+++ b/app/controllers/departments/update.js
@@ -4,7 +4,7 @@ import { DEFAULT_ERROR_MESSAGE } from 'app/utils/backend/constants';
 
 const updateDepartement = async (params) => {
   const {
-    department_id, name, is_active, ManagerDepartmet,
+    department_id, name, is_active, ManagerDepartmet, SubstituteManager,
   } = params;
 
   if (typeof department_id !== 'number') {
@@ -22,7 +22,8 @@ const updateDepartement = async (params) => {
     data: {
       name,
       is_active,
-      manager_employee_id: ManagerDepartmet.employee_id,
+      manager_employee_id: ManagerDepartmet ? ManagerDepartmet.employee_id : null,
+      alternate_manager_id: SubstituteManager ? SubstituteManager.employee_id : null,
     },
   });
 

--- a/app/controllers/questions/create.js
+++ b/app/controllers/questions/create.js
@@ -65,23 +65,35 @@ const createQuestion = async (
         where: {
           department_id: created.assigned_department,
         },
-        include: { ManagerDepartmet: true },
-      }))).ManagerDepartmet;
+        include: { ManagerDepartmet: true, AlternateManager: true },
+      })));
     }
+    const { ManagerDepartmet, AlternateManager } = departmentManager;
 
-    const destinationEmail = departmentManager ? departmentManager.email : defaultManagerEmail;
-    const destinationName = departmentManager ? departmentManager.full_name : defaultManagerName;
+    const destinationEmail = ManagerDepartmet ? ManagerDepartmet.email : defaultManagerEmail;
+    const destinationName = ManagerDepartmet ? ManagerDepartmet.full_name : defaultManagerName;
+
+    const mailList = [destinationEmail];
+    const nameList = [destinationName];
+
+    const destinationEmailSub = AlternateManager ? AlternateManager.email : undefined;
+    const destinationNameSub = AlternateManager ? AlternateManager.full_name : undefined;
+
+    if (destinationEmailSub) {
+      mailList.push(destinationEmailSub);
+      nameList.push(destinationNameSub);
+    }
 
     const emailProperties = value.is_anonymous
       ? EMAILS.anonymousQuestionAssigned
       : EMAILS.publicQuestionAssigned;
 
     await sendEmail({
-      to: destinationEmail,
+      to: mailList.join(','),
       subject: emailProperties.subject,
       template: emailProperties.template,
       context: {
-        name: destinationName,
+        name: nameList.join(' | '),
         question_url: getQuestionDetailUrl(created.question_id),
         question_text: created.question,
       },

--- a/app/routes/admin.jsx
+++ b/app/routes/admin.jsx
@@ -68,6 +68,7 @@ export const action = async ({ request }) => {
           department_id: parseInt(formData.get('department_id'), 10),
           name: formData.get('name'),
           ManagerDepartmet: JSON.parse(formData.get('ManagerDepartmet')),
+          SubstituteManager: JSON.parse(formData.get('AlternateManager')),
         },
       );
       break;

--- a/prisma/migrations/20230428010538_add_alternate_manager/migration.sql
+++ b/prisma/migrations/20230428010538_add_alternate_manager/migration.sql
@@ -1,0 +1,8 @@
+-- AlterTable
+ALTER TABLE `Departments` ADD COLUMN `alternate_manager_id` INTEGER NULL;
+
+-- CreateIndex
+CREATE INDEX `Departments_alternate_manager_employee_id` ON `Departments`(`alternate_manager_id`);
+
+-- AddForeignKey
+ALTER TABLE `Departments` ADD CONSTRAINT `Departments_alternate_manager_id_fkey` FOREIGN KEY (`alternate_manager_id`) REFERENCES `users`(`employee_id`) ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -67,10 +67,13 @@ model Departments {
   name                String      @db.VarChar(255)
   is_active           Boolean     @default(true)
   manager_employee_id Int?
-  ManagerDepartmet    users?      @relation(fields: [manager_employee_id], references: [employee_id])
+  alternate_manager_id  Int?
+  ManagerDepartmet    users?      @relation("Manager", fields: [manager_employee_id], references: [employee_id])
+  AlternateManager    users?       @relation("SubManager", fields: [alternate_manager_id], references: [employee_id])
   Questions           Questions[]
 
   @@index([manager_employee_id], map: "Departments_manager_employee_id")
+  @@index([alternate_manager_id], map: "Departments_alternate_manager_employee_id")
 }
 
 model DraftAnswers {
@@ -195,7 +198,8 @@ model users {
   Answers              Answers[]
   CommentsApproved     Comments[]             @relation("Comments_approvedByTousers")
   CommentsCreated      Comments[]             @relation("Comments_userEmailTousers")
-  ManagerDepartments   Departments[]
+  ManagerDepartments   Departments[]          @relation("Manager")
+  AlternateManager     Departments[]          @relation("SubManager")
 
   @@index([email], map: "users_email")
 }

--- a/tests/integration/controllers/deparments/update.test.js
+++ b/tests/integration/controllers/deparments/update.test.js
@@ -1,0 +1,41 @@
+import updateDepartement from 'app/controllers/departments/update';
+
+describe('updateDepartment', () => {
+  it('Add Manager', async () => {
+    const payload = {
+      department_id: 2,
+      name: 'Academy',
+      is_active: true,
+      ManagerDepartmet: {
+        employee_id: 2,
+        full_name: 'John Doe',
+      },
+    };
+    const response = await updateDepartement(payload);
+    expect(response).toBeDefined();
+    expect(response.successMessage).toBeDefined();
+    expect(response.updatedDepartment.manager_employee_id)
+      .toEqual(payload.ManagerDepartmet.employee_id);
+  });
+
+  it('Add Substiture', async () => {
+    const payload = {
+      department_id: 2,
+      name: 'Academy',
+      is_active: true,
+      ManagerDepartmet: {
+        employee_id: 2,
+        full_name: 'John Doe',
+      },
+      SubstituteManager: {
+        employee_id: 3,
+        full_name: 'Will Smith',
+      },
+    };
+    const response = await updateDepartement(payload);
+    expect(response).toBeDefined();
+    expect(response.successMessage).toBeDefined();
+    expect(response.updatedDepartment.alternate_manager_id)
+      .toEqual(payload.SubstituteManager.employee_id);
+  });
+});


### PR DESCRIPTION
#### What does this PR do?
- adds a new field to save a substitute of a manager. 
- modify the `createQuestion` controller to send an email to the substitute of a manager. 


#### How should this be manually tested?
1. Login as admin
2. Go to the admin option.
3. Go to the departments tab.
4. Select any department and add a manager and a substitute. 

#### What are the relevant tickets?
(Link to issues, related PR, JIRA issues, etc.)
Closes #212 
