### PR TITLE
feat: send email when re-assigned a question

### DIFF
--- a/app/config/flags.json
+++ b/app/config/flags.json
@@ -1,5 +1,6 @@
 {
   "requireEmployeeAssigned": false,
   "sendEmailToManagerOnQuestionCreation": true,
-  "sendSlackOnQuestionCreation": true
+  "sendSlackOnQuestionCreation": true,
+  "sendEmailOnQuestionReassigned": true
 }

--- a/tests/integration/controllers/questions/assignQuestion.test.js
+++ b/tests/integration/controllers/questions/assignQuestion.test.js
@@ -1,6 +1,14 @@
 import assignQuestion from 'app/controllers/questions/assignQuestion';
+import emailHandler from 'app/utils/backend/emails/emailHandler';
+import { EMAILS } from 'app/utils/backend/emails/emailConstants';
 
 describe('assignQuestion', () => {
+  const emailHandlerSpy = jest.spyOn(emailHandler, 'sendEmail').mockImplementation();
+
+  afterEach(() => {
+    emailHandlerSpy.mockClear();
+  });
+
   it('assign question correctly', async () => {
     const payload = {
       question_id: 4,
@@ -12,6 +20,27 @@ describe('assignQuestion', () => {
     expect(response).toBeDefined();
     expect(response.successMessage).toBeDefined();
     expect(response.assignedQuestion.assigned_department).toEqual(payload.assigned_department);
+  });
+
+  it('sends email to the new person assigned', async () => {
+    const payload = {
+      question_id: 4,
+      assigned_department: 4,
+      assigned_to_employee_id: 4,
+    };
+    const response = await assignQuestion(payload);
+    expect(response).toBeDefined();
+    expect(emailHandlerSpy).toHaveBeenCalledTimes(1);
+    expect(emailHandlerSpy).toHaveBeenCalledWith({
+      subject: EMAILS.publicQuestionAssigned.subject,
+      to: 'eduardo.garibo@wizeline.com',
+      template: EMAILS.publicQuestionAssigned.template,
+      context: {
+        name: 'Eduardo Mendoza Garibo',
+        question_text: expect.any(String),
+        question_url: expect.any(String),
+      },
+    });
   });
 
   it('returns an error when the question is not found', async () => {


### PR DESCRIPTION
#### What does this PR do?
- add a flag to send an email when re-assigned a question 
- Send an email to the new person 

#### Where should the reviewer start?
- To test the emails locally, you can send me a slack to share the .env credentials of [Mailtrap](https://mailtrap.io/) or create your own account and use your own credentials.


#### What are the relevant tickets?
Closes #210 
