### PR TITLE
fix: EmployeesDepartments controllers and fetch requireEmployeeAssign…

### DIFF
--- a/app/components/QuestionForm/QuestionForm.jsx
+++ b/app/components/QuestionForm/QuestionForm.jsx
@@ -92,7 +92,7 @@ function QuestionForm({
         });
       }
     };
-    fetchEmployees();
+    if (requireEmployeeAssigned) fetchEmployees();
   }, [state.assignedDepartment]);
 
   useEffect(() => {

--- a/app/controllers/employees/list.js
+++ b/app/controllers/employees/list.js
@@ -5,6 +5,11 @@ const listEmployees = async (id) => {
   const relations = await db.EmployeesDepartments.findMany({
     where: {
       department_id: idValue,
+      NOT: [
+        {
+          employee_id: null,
+        },
+      ],
     },
     distinct: ['email'],
     include: {


### PR DESCRIPTION
#### What does this PR do?
-  adds an attribute to the `where` clause to filter the employees list according to the department and with `employee_id` different to null.
- fetch employee list when the flag `requireEmployeeAssigned`  is `true`

#### How should this be manually tested?
1. Create a question and select “engineering” as department 
2. go to the config file (app/config/flags.json) and change the value of  `requireEmployeeAssigned` to true.
3. Create a question and select “engineering” as department. Verify that you can select an employee. 
4. :tada:


#### What are the relevant tickets?
(Link to issues, related PR, JIRA issues, etc.)
Closes #218 
