### PR TITLE
feat(infra): add terraform code to create gcp scheduler for api calls

### DIFF
--- a/app/routes/api/emails/sendManagerReminder.jsx
+++ b/app/routes/api/emails/sendManagerReminder.jsx
@@ -4,9 +4,18 @@
 import { sendManagerReminder } from 'app/controllers/emails/sendManagerReminder';
 import { json } from '@remix-run/node';
 import { sendManagersEmailReminder } from 'app/config/flags.json';
+import validateKey from 'app/utils/backend/api/validateKey';
 
-export const loader = async () => {
-  // INSERT KEY VALIDATION
+export const loader = () => {
+  throw new Response(null, { status: 404, statusText: 'Not Found' });
+};
+
+export const action = async ({ request }) => {
+  const { error: keyValidationError } = validateKey(request);
+
+  if (keyValidationError) {
+    return json({ success: false, detail: keyValidationError }, 400);
+  }
 
   if (sendManagersEmailReminder) {
     const { error, emailsQueue } = await sendManagerReminder();

--- a/app/utils/backend/api/validateKey.js
+++ b/app/utils/backend/api/validateKey.js
@@ -1,0 +1,17 @@
+require('dotenv').config();
+
+const validateKey = (request) => {
+  const key = request.headers.get('API_KEY');
+
+  if (!key) {
+    return { error: 'API key not provided', valid: false };
+  }
+
+  if (process.env.API_KEY && process.env.API_KEY !== key) {
+    return { error: 'API key does not match required', valid: false };
+  }
+
+  return { valid: true };
+};
+
+module.exports = validateKey;

--- a/infrastructure/terraform/data.tf
+++ b/infrastructure/terraform/data.tf
@@ -64,3 +64,7 @@ data "google_secret_manager_secret_version" "Email_auth_password" {
 data "google_secret_manager_secret_version" "Email_service" {
   secret = "${var.secret_prefix}_REMIX_EMAIL_SERVICE"
 }
+
+data "google_secret_manager_secret_version" "Api_key" {
+  secret = "${var.secret_prefix}_REMIX_API_KEY"
+}

--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -16,14 +16,15 @@ module "cloud_run" {
   node_env            = data.google_secret_manager_secret_version.Node_env.secret_data
   slack_webhook_url   = data.google_secret_manager_secret_version.Slack_webhook_url.secret_data
   slack_wizeq_domain  = data.google_secret_manager_secret_version.Slack_wizeq_domain.secret_data
-  db_url         = "mysql://${data.google_secret_manager_secret_version.Db_user.secret_data}:${data.google_secret_manager_secret_version.Db_password.secret_data}@${module.cloud_sql.db_host}/${data.google_secret_manager_secret_version.Db_name.secret_data}"
-  base_url       = data.google_secret_manager_secret_version.Wizeq_url.secret_data
-  session_secret = data.google_secret_manager_secret_version.Session_secret.secret_data
-  email_host = data.google_secret_manager_secret_version.Email_host.secret_data
-  email_port = data.google_secret_manager_secret_version.Email_port.secret_data
-  email_auth_user = data.google_secret_manager_secret_version.Email_auth_user.secret_data
+  db_url              = "mysql://${data.google_secret_manager_secret_version.Db_user.secret_data}:${data.google_secret_manager_secret_version.Db_password.secret_data}@${module.cloud_sql.db_host}/${data.google_secret_manager_secret_version.Db_name.secret_data}"
+  base_url            = data.google_secret_manager_secret_version.Wizeq_url.secret_data
+  session_secret      = data.google_secret_manager_secret_version.Session_secret.secret_data
+  email_host          = data.google_secret_manager_secret_version.Email_host.secret_data
+  email_port          = data.google_secret_manager_secret_version.Email_port.secret_data
+  email_auth_user     = data.google_secret_manager_secret_version.Email_auth_user.secret_data
   email_auth_password = data.google_secret_manager_secret_version.Email_auth_password.secret_data
-  email_service = data.google_secret_manager_secret_version.Email_service.secret_data
+  email_service       = data.google_secret_manager_secret_version.Email_service.secret_data
+  api_key             = data.google_secret_manager_secret_version.Api_key.secret_data
   // db_host            = module.cloud_sql.db_host
   // db_connection_name = module.cloud_sql.db_connection_name
 }
@@ -33,11 +34,31 @@ module "cloud_sql" {
 
   prefix = local.prefix
 
-  db_tier            = var.db_tier
-  sql_version        = var.sql_version
-  region             = var.region
+  db_tier     = var.db_tier
+  sql_version = var.sql_version
+  region      = var.region
+
   secret_db_user     = data.google_secret_manager_secret_version.Db_user.secret_data
   secret_db_password = data.google_secret_manager_secret_version.Db_password.secret_data
   db_name            = data.google_secret_manager_secret_version.Db_name.secret_data
 
 }
+
+module "cloud_scheduler_manager_email_queue" {
+  source      = "./modules/cloud_scheduler"
+
+  prefix = local.prefix
+
+  name        = "api_manager_email_queue_call"
+  description = "API call for manager email queue"
+  enabled     = true
+
+  http_target = {
+    http_method = "POST",
+    uri         = join("/", [data.google_secret_manager_secret_version.Wizeq_url.secret_data, "api", "emails", "sendManagerReminder"])
+    body        = "{}"
+    apiKey      = data.google_secret_manager_secret_version.Api_key.secret_data
+  }
+}
+
+

--- a/infrastructure/terraform/modules/cloud_run/cloud_run.tf
+++ b/infrastructure/terraform/modules/cloud_run/cloud_run.tf
@@ -68,6 +68,10 @@ resource "google_cloud_run_service" "app" {
           name = "EMAIL_SERVICE"
           value = var.email_service
         }
+        env {
+          name = "API_KEY"
+          value = var.api_key
+        }
       }
 
     }

--- a/infrastructure/terraform/modules/cloud_run/variables.tf
+++ b/infrastructure/terraform/modules/cloud_run/variables.tf
@@ -92,6 +92,10 @@ variable "email_auth_password" {
   type = string
 }
 
+variable "api_key" {
+  type = string
+}
+
 # variable "db_connection_name" {
 #   type = string
 # }

--- a/infrastructure/terraform/modules/cloud_scheduler/main.tf
+++ b/infrastructure/terraform/modules/cloud_scheduler/main.tf
@@ -1,0 +1,23 @@
+resource "google_cloud_scheduler_job" "scheduler_job" {
+  name = "${var.prefix}-${var.name}"
+  description = var.description
+  schedule = var.schedule
+  time_zone = var.timezone
+  attempt_deadline = "320s"
+  paused = !var.enabled
+
+  retry_config {
+    retry_count = 1
+  }
+
+  http_target {
+    http_method = var.http_target.http_method 
+    uri = var.http_target.uri
+    body = base64encode(var.http_target.body)
+
+    headers = {
+      API_KEY = var.http_target.apiKey
+    }
+  }
+}
+

--- a/infrastructure/terraform/modules/cloud_scheduler/variables.tf
+++ b/infrastructure/terraform/modules/cloud_scheduler/variables.tf
@@ -1,0 +1,47 @@
+variable "prefix" {
+  description = "Prefix name for all resources"
+  default     = "wizeq"
+  type        = string
+}
+
+
+variable "name" {
+  description = "Name of the scheduler"
+  type = string
+}
+
+
+variable "description" {
+  description = "Optional descriptor for the scheduler"
+  type = string
+  default = ""
+}
+
+variable "enabled" {
+  description = "Pauses scheduler if needed"
+  type = bool
+  default = true
+}
+
+variable "timezone" {
+  description = "Timezone that will be used to determine trigger"
+  type = string
+  default = "America/Mexico_City"
+}
+
+variable "schedule" {
+  description = "UNIX type scheduler string"
+  default = "0 10 * * *"
+  type = string
+}
+
+variable "http_target" {
+  type = object({
+    http_method = string
+    uri = string
+    body = string
+    apiKey = string
+  })
+  sensitive = true
+  
+}


### PR DESCRIPTION
#### What does this PR do?
- Adds terraform infrastructure code to add gcp scheduler that will call the new email endpoint
- Changes api http method to a POST and require a environment provided KEY header

*- Emails for assigned employees will be handled in a different PR. 