### PR TITLE
fix: email previous date validation offset

### DIFF
--- a/app/config/emails.json
+++ b/app/config/emails.json
@@ -1,5 +1,6 @@
 {
   "defaultManagerEmail": "wizeq@wizeline.com",
   "defaultManagerName": "Wizeliner",
-  "managerEmailFrequencyHours": 24
+  "managerEmailFrequencyHours": 24,
+  "scheduledMinutesOffset": 5
 }

--- a/app/controllers/emails/sendManagerReminder.js
+++ b/app/controllers/emails/sendManagerReminder.js
@@ -2,14 +2,15 @@ const { getPendingEmailsForDepartments } = require('app/controllers/emails/getPe
 const { sendEmail } = require('app/utils/backend/emails/emailHandler');
 const { db } = require('app/utils/db.server');
 
-const { managerEmailFrequencyHours } = require('app/config/emails.json');
+const { managerEmailFrequencyHours, scheduledMinutesOffset } = require('app/config/emails.json');
 
 const subtractOriginalDate = (date, hours) => {
   const result = new Date(date);
   result.setHours(result.getHours() - hours);
 
   // Substract an offset of minutes to not have race conditions with scheduler
-  result.setMinutes(result.getMinutes() - 5);
+  const minutesOffset = scheduledMinutesOffset ?? 5;
+  result.setMinutes(result.getMinutes() - minutesOffset);
   return result;
 };
 

--- a/app/controllers/emails/sendManagerReminder.js
+++ b/app/controllers/emails/sendManagerReminder.js
@@ -4,9 +4,12 @@ const { db } = require('app/utils/db.server');
 
 const { managerEmailFrequencyHours } = require('app/config/emails.json');
 
-const subtractHours = (date, hours) => {
+const subtractOriginalDate = (date, hours) => {
   const result = new Date(date);
   result.setHours(result.getHours() - hours);
+
+  // Substract an offset of minutes to not have race conditions with scheduler
+  result.setMinutes(result.getMinutes() - 5);
   return result;
 };
 
@@ -15,7 +18,7 @@ const sendManagerReminder = async (
   emailFrequency = managerEmailFrequencyHours,
 ) => {
   const originalDate = currentDate;
-  const previousDate = subtractHours(originalDate, emailFrequency);
+  const previousDate = subtractOriginalDate(originalDate, emailFrequency);
 
   try {
     const departments = await db.Departments.findMany({

--- a/tests/integration/controllers/emails/sendReminder.test.js
+++ b/tests/integration/controllers/emails/sendReminder.test.js
@@ -44,6 +44,13 @@ describe('sendReminder', () => {
     expect(dbDepartmentsListSpy).toHaveBeenCalledTimes(1);
   });
 
+  it('uses previous date with offset to check for last notification timedate', () => {
+    const mockCall = dbDepartmentsListSpy.mock.calls[0][0];
+    const { last_manager_email_notification_date: lastDate } = mockCall.where.OR[0];
+    expect(lastDate.lte).toBeDefined();
+    expect(lastDate.lte.getTime()).toBeLessThan(currentDateMock.getTime());
+  });
+
   it('calls pending emails for active deparments', () => {
     expect(getPendingEmailsForDepartments).toHaveBeenCalledTimes(1);
     const departmentsList = getPendingEmailsForDepartments.mock.calls[0][0];


### PR DESCRIPTION
#### What does this PR do?
- Fixes issue where no emails where queued given a race condition. Adds a 5 minute offset to make sure emails are sent after 24 hours.
