### PR TITLE
fix(emails): send email error catch

### DIFF
--- a/app/utils/backend/emails/emailHandler.js
+++ b/app/utils/backend/emails/emailHandler.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 const { EMAIL_SUBJECT_PREFIX } = require('app/utils/backend/emails/emailConstants');
 const { instantiateTransporter } = require('app/utils/backend/emails/emailTransporter');
 const { sendEmailSchema } = require('app/utils/backend/validators/email');
@@ -16,10 +17,15 @@ const sendEmail = async (message) => {
     transformedSubject = `${EMAIL_SUBJECT_PREFIX}${message.subject}`;
   }
 
-  await transporter.sendMail({
-    ...message,
-    subject: transformedSubject,
-  });
+  try {
+    await transporter.sendMail({
+      ...message,
+      subject: transformedSubject,
+    });
+  } catch (sendEmailError) {
+    // TODO: Improve error logging
+    console.error('Email handler error: ', sendEmailError);
+  }
 };
 
 module.exports = {

--- a/infrastructure/terraform/data.tf
+++ b/infrastructure/terraform/data.tf
@@ -50,23 +50,23 @@ data "google_secret_manager_secret_version" "Session_secret" {
   secret = "${var.secret_prefix}_SESSION_SECRET"
 }
 data "google_secret_manager_secret_version" "Email_host" {
-  secret = "${var.secret_prefix}_REMIX_EMAIL_HOST"
+  secret = "PROD_REMIX_EMAIL_HOST"
 }
 
 data "google_secret_manager_secret_version" "Email_port" {
-  secret = "${var.secret_prefix}_REMIX_EMAIL_PORT"
+  secret = "PROD_REMIX_EMAIL_PORT"
 }
 
 data "google_secret_manager_secret_version" "Email_auth_user" {
-  secret = "${var.secret_prefix}_REMIX_EMAIL_AUTH_USER"
+  secret = "PROD_REMIX_EMAIL_AUTH_USER"
 }
 
 data "google_secret_manager_secret_version" "Email_auth_password" {
-  secret = "${var.secret_prefix}_REMIX_EMAIL_AUTH_PASSWORD"
+  secret = "PROD_REMIX_EMAIL_AUTH_PASSWORD"
 }
 
 data "google_secret_manager_secret_version" "Email_service" {
-  secret = "${var.secret_prefix}_REMIX_EMAIL_SERVICE"
+  secret = "PROD_REMIX_EMAIL_SERVICE"
 }
 
 data "google_secret_manager_secret_version" "Api_key" {

--- a/infrastructure/terraform/data.tf
+++ b/infrastructure/terraform/data.tf
@@ -50,23 +50,23 @@ data "google_secret_manager_secret_version" "Session_secret" {
   secret = "${var.secret_prefix}_SESSION_SECRET"
 }
 data "google_secret_manager_secret_version" "Email_host" {
-  secret = "PROD_REMIX_EMAIL_HOST"
+  secret = "PROD_EMAIL_HOST"
 }
 
 data "google_secret_manager_secret_version" "Email_port" {
-  secret = "PROD_REMIX_EMAIL_PORT"
+  secret = "PROD_EMAIL_PORT"
 }
 
 data "google_secret_manager_secret_version" "Email_auth_user" {
-  secret = "PROD_REMIX_EMAIL_AUTH_USER"
+  secret = "PROD_EMAIL_AUTH_USER"
 }
 
 data "google_secret_manager_secret_version" "Email_auth_password" {
-  secret = "PROD_REMIX_EMAIL_AUTH_PASSWORD"
+  secret = "PROD_EMAIL_AUTH_PASSWORD"
 }
 
 data "google_secret_manager_secret_version" "Email_service" {
-  secret = "PROD_REMIX_EMAIL_SERVICE"
+  secret = "PROD_EMAIL_SERVICE"
 }
 
 data "google_secret_manager_secret_version" "Api_key" {

--- a/infrastructure/terraform/data.tf
+++ b/infrastructure/terraform/data.tf
@@ -50,23 +50,23 @@ data "google_secret_manager_secret_version" "Session_secret" {
   secret = "${var.secret_prefix}_SESSION_SECRET"
 }
 data "google_secret_manager_secret_version" "Email_host" {
-  secret = "PROD_REMIX_EMAIL_HOST"
+  secret = "${var.secret_prefix}_REMIX_EMAIL_HOST"
 }
 
 data "google_secret_manager_secret_version" "Email_port" {
-  secret = "PROD_REMIX_EMAIL_PORT"
+  secret = "${var.secret_prefix}_REMIX_EMAIL_PORT"
 }
 
 data "google_secret_manager_secret_version" "Email_auth_user" {
-  secret = "PROD_REMIX_EMAIL_AUTH_USER"
+  secret = "${var.secret_prefix}_REMIX_EMAIL_AUTH_USER"
 }
 
 data "google_secret_manager_secret_version" "Email_auth_password" {
-  secret = "PROD_REMIX_EMAIL_AUTH_PASSWORD"
+  secret = "${var.secret_prefix}_REMIX_EMAIL_AUTH_PASSWORD"
 }
 
 data "google_secret_manager_secret_version" "Email_service" {
-  secret = "PROD_REMIX_EMAIL_SERVICE"
+  secret = "${var.secret_prefix}_REMIX_EMAIL_SERVICE"
 }
 
 data "google_secret_manager_secret_version" "Api_key" {

--- a/infrastructure/terraform/data.tf
+++ b/infrastructure/terraform/data.tf
@@ -50,23 +50,23 @@ data "google_secret_manager_secret_version" "Session_secret" {
   secret = "${var.secret_prefix}_SESSION_SECRET"
 }
 data "google_secret_manager_secret_version" "Email_host" {
-  secret = "PROD_EMAIL_HOST"
+  secret = "PROD_REMIX_EMAIL_HOST"
 }
 
 data "google_secret_manager_secret_version" "Email_port" {
-  secret = "PROD_EMAIL_PORT"
+  secret = "PROD_REMIX_EMAIL_PORT"
 }
 
 data "google_secret_manager_secret_version" "Email_auth_user" {
-  secret = "PROD_EMAIL_AUTH_USER"
+  secret = "PROD_REMIX_EMAIL_AUTH_USER"
 }
 
 data "google_secret_manager_secret_version" "Email_auth_password" {
-  secret = "PROD_EMAIL_AUTH_PASSWORD"
+  secret = "PROD_REMIX_EMAIL_AUTH_PASSWORD"
 }
 
 data "google_secret_manager_secret_version" "Email_service" {
-  secret = "PROD_EMAIL_SERVICE"
+  secret = "PROD_REMIX_EMAIL_SERVICE"
 }
 
 data "google_secret_manager_secret_version" "Api_key" {


### PR DESCRIPTION
#### What does this PR do?
- Adds try/catch to email handler so errors are output in console instead of causing 500s
- Temporal terraform force to use prod email services. Will revert this change onee it's tested. 