### PR TITLE
fix: wizeq is indexed by google 

### DIFF
--- a/app/root.jsx
+++ b/app/root.jsx
@@ -27,6 +27,7 @@ export const meta = () => ({
   charset: 'utf-8',
   title: `Wizeline Questions${titleSuffix}`,
   viewport: 'width=device-width,initial-scale=1',
+  robots: 'noindex'
 });
 
 export function links() {


### PR DESCRIPTION
#### What does this PR do?
- add the meta robots with nonindex value. 

#### Where should the reviewer start?
- app/root.jsx

#### How should this be manually tested?
1. run the app and verify that you can see the meta with the devtools.


#### Any background context you want to provide?
https://developers.google.com/search/docs/crawling-indexing/block-indexing?hl=es-419#:~:text=noindex%20is%20a%20rule%20set,noindex%20rule%2C%20such%20as%20Google

#### What are the relevant tickets?
(Link to issues, related PR, JIRA issues, etc.)
Closes #249 

