### PR TITLE
feat: Added missing headers to the server

### DIFF
--- a/app/entry.server.jsx
+++ b/app/entry.server.jsx
@@ -19,8 +19,12 @@ export default function handleRequest(
   const styles = sheet.getStyleTags();
 
   markup = markup.replace('__STYLES__', styles);
-
+  responseHeaders.set('Content-Security-Policy', "script-src 'unsafe-inline' 'self';");
+  responseHeaders.set('X-Frame-Options', 'SAMEORIGIN');
+  responseHeaders.set('Strict-Transport-Security', 'max-age=31536000; includeSubDomains');
+  responseHeaders.set('X-Content-Type-Options', 'nosniff');
   responseHeaders.set('Content-Type', 'text/html');
+
   return new Response(`<!DOCTYPE html>${markup}`, {
     status: responseStatusCode,
     headers: responseHeaders,


### PR DESCRIPTION
#### What does this PR do?
This pull request added missing headers on the server for better security policies

#### Where should the reviewer start?
app/entry.server.jsx

#### How should this be manually tested?
(List of steps to reproduce, corroborate or tests to run. Write this section clear enough so that external users can also follow it and test the fix.)
1. Access the application
2. Open the network tab
3. Check the page delivered headers
4. Verify the following headers are present: 

- Content Security Policy
- Anti-clickjacking
- HTTP Strict Transport Security
- X-Content-Type-Options : The Anti-MIME-Sniffing header X-Content-Type-Options was not set to 'nosniff'.
- 

#### What are the relevant tickets?
(Link to issues, related PR, JIRA issues, etc.)
Closes #228 

#### Screenshots
![image](https://github.com/wizeline/wize-q-remix/assets/97201781/3841c2bd-d13c-45ba-9f30-718aff9c3a60)

#### Questions
:question: