### PR TITLE
chore(infra): remove unused mysql cloud sql instances from TF state

### DIFF
--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -30,21 +30,6 @@ module "cloud_run" {
   // db_connection_name = module.cloud_sql.db_connection_name
 }
 
-module "cloud_sql" {
-  source = "./modules/cloud_sql"
-
-  prefix = local.prefix
-
-  db_tier     = var.db_tier
-  sql_version = var.sql_version
-  region      = var.region
-
-  secret_db_user     = data.google_secret_manager_secret_version.Db_user.secret_data
-  secret_db_password = data.google_secret_manager_secret_version.Db_password.secret_data
-  db_name            = data.google_secret_manager_secret_version.Db_name.secret_data
-
-}
-
 module "cloud_sql_postgres" {
   source = "./modules/cloud_sql"
 


### PR DESCRIPTION
#### What does this PR do?
- Removes Terraform code for deprecated MySQL modules in favor of the new Postgres ones that are used. We couldn't stop the instances without removing these. Just in case these are ever needed, the resources still exist on GCP but "stopped". I ran "terraform state rm cloud_sql.*" for each resource unused so Terraform doesn't track the state of these resources, and we can stop the service in GCP without deleting them forcefully. 

