### PR TITLE
feat: add controller to create and fetch tags. 

### DIFF
--- a/app/controllers/comments/tags/create.js
+++ b/app/controllers/comments/tags/create.js
@@ -1,4 +1,3 @@
-/* eslint-disable camelcase */
 import { db } from 'app/utils/db.server';
 import { commentTagsCreatedSchema } from 'app/utils/validators/comments';
 import { DEFAULT_ERROR_MESSAGE } from 'app/utils/constants';
@@ -14,10 +13,10 @@ const createTag = async (params) => {
     };
   }
   try {
-    const { tag_text } = value;
+    const { tagText } = value;
     const tag = await db.commenttags.create({
       data: {
-        tag_text,
+        tag_text: tagText,
       },
     });
     return {

--- a/app/controllers/comments/tags/create.js
+++ b/app/controllers/comments/tags/create.js
@@ -1,0 +1,37 @@
+/* eslint-disable camelcase */
+import { db } from 'app/utils/db.server';
+import { commentTagsCreatedSchema } from 'app/utils/validators/comments';
+import { DEFAULT_ERROR_MESSAGE } from 'app/utils/constants';
+
+const createTag = async (params) => {
+  const { value, error } = commentTagsCreatedSchema.validate(params);
+  if (error) {
+    return {
+      error: {
+        message: DEFAULT_ERROR_MESSAGE,
+        details: error,
+      },
+    };
+  }
+  try {
+    const { tag_text } = value;
+    const tag = await db.commenttags.create({
+      data: {
+        tag_text,
+      },
+    });
+    return {
+      successMessage: 'The tag was created succesfully.',
+      tag,
+    };
+  } catch (cathError) {
+    return {
+      error: {
+        message: 'Something went wrong creating the tag!',
+        details: cathError,
+      },
+    };
+  }
+};
+
+export default createTag;

--- a/app/controllers/comments/tags/list.js
+++ b/app/controllers/comments/tags/list.js
@@ -1,0 +1,32 @@
+import { DEFAULT_TAGS_LIMIT } from 'app/utils/constants';
+import { db } from 'app/utils/db.server';
+
+const whereSearchTerm = (searchTerm) => {
+  if (!searchTerm) { return {}; }
+
+  return {
+    tag_text: {
+      contains: searchTerm,
+    },
+  };
+};
+
+const buildWhere = (searchTerm) => {
+  const where = {
+    ...whereSearchTerm(searchTerm),
+  };
+  return where;
+};
+
+const ListTags = async (params) => {
+  const { searchTerm, limit, offset } = params;
+  const tags = await db.commenttags.findMany({
+    where: buildWhere(searchTerm),
+    take: limit || DEFAULT_TAGS_LIMIT,
+    skip: offset || 0,
+  });
+
+  return { tags };
+};
+
+export default ListTags;

--- a/app/utils/constants.js
+++ b/app/utils/constants.js
@@ -343,3 +343,4 @@ export const MAX_NET_PROMOTER_SCORE = 4;
 export const DEFAULT_ERROR_MESSAGE = 'An unknown error has occurred with your request.';
 export const COMMENT_AS_AN_ANSWER = 'This question already has a comment as answer';
 export const DEFAULT_MONTHS = -3;
+export const DEFAULT_TAGS_LIMIT = 5;

--- a/app/utils/validators/comments.js
+++ b/app/utils/validators/comments.js
@@ -46,5 +46,5 @@ export const tagCommentSchema = Joi.object().keys({
 });
 
 export const commentTagsCreatedSchema = Joi.object().keys({
-  tag_text: JOI_SIMPLE_STRING_VALIDATION,
+  tagText: JOI_SIMPLE_STRING_VALIDATION,
 });

--- a/app/utils/validators/comments.js
+++ b/app/utils/validators/comments.js
@@ -44,3 +44,7 @@ export const tagCommentSchema = Joi.object().keys({
   tagId: SIMPLE_INTEGER_VALIDATION.allow(null),
   taggedBy: Joi.string().allow(null),
 });
+
+export const commentTagsCreatedSchema = Joi.object().keys({
+  tag_text: JOI_SIMPLE_STRING_VALIDATION,
+});

--- a/tests/fixtures/tags.json
+++ b/tests/fixtures/tags.json
@@ -1,3 +1,9 @@
 [{
   "tag_text" : "Violate guidelines"
+},
+{
+  "tag_text": "Rude Comment"
+}, 
+{
+  "tag_text":"Another tag for a comment"
 }]

--- a/tests/integration/controllers/comments/tags/createTags.test.js
+++ b/tests/integration/controllers/comments/tags/createTags.test.js
@@ -3,13 +3,13 @@ import { DEFAULT_ERROR_MESSAGE } from 'app/utils/constants';
 
 describe('create tag', () => {
   it('create a new tag ', async () => {
-    const data = { tag_text: 'rude comment violates the community guideline' };
+    const data = { tagText: 'rude comment violates the community guideline' };
     const response = await createTag(data);
     expect(response).toBeDefined();
     expect(response.successMessage).toEqual('The tag was created succesfully.');
     expect(response.tag).toBeDefined();
     expect(response.tag.tag_id).toBe(4);
-    expect(response.tag.tag_text).toBe(data.tag_text);
+    expect(response.tag.tag_text).toBe(data.tagText);
   });
 
   it('error sending an empty object', async () => {

--- a/tests/integration/controllers/comments/tags/createTags.test.js
+++ b/tests/integration/controllers/comments/tags/createTags.test.js
@@ -1,0 +1,21 @@
+import createTag from 'app/controllers/comments/tags/create';
+import { DEFAULT_ERROR_MESSAGE } from 'app/utils/constants';
+
+describe('create tag', () => {
+  it('create a new tag ', async () => {
+    const data = { tag_text: 'rude comment violates the community guideline' };
+    const response = await createTag(data);
+    expect(response).toBeDefined();
+    expect(response.successMessage).toEqual('The tag was created succesfully.');
+    expect(response.tag).toBeDefined();
+    expect(response.tag.tag_id).toBe(4);
+    expect(response.tag.tag_text).toBe(data.tag_text);
+  });
+
+  it('error sending an empty object', async () => {
+    const response = await createTag({});
+    expect(response).toBeDefined();
+    expect(response.error).toBeDefined();
+    expect(response.error.message).toEqual(DEFAULT_ERROR_MESSAGE);
+  });
+});

--- a/tests/integration/controllers/comments/tags/listTags.test.js
+++ b/tests/integration/controllers/comments/tags/listTags.test.js
@@ -1,0 +1,24 @@
+import ListTags from 'app/controllers/comments/tags/list';
+
+describe('list tags', () => {
+  it('return all the tags', async () => {
+    const response = await ListTags({});
+    expect(response).toBeDefined();
+    expect(response.tags).toBeDefined();
+    expect(response.tags.length).toBe(3);
+  });
+
+  it('return by search term - Violate', async () => {
+    const response = await ListTags({ searchTerm: 'Violate' });
+    expect(response).toBeDefined();
+    expect(response.tags).toBeDefined();
+    expect(response.tags[0].tag_id).toBe(1);
+  });
+
+  it('retunr an empty list', async () => {
+    const response = await ListTags({ searchTerm: 'abc' });
+    expect(response).toBeDefined();
+    expect(response.tags).toBeDefined();
+    expect(response.tags.length).toBe(0);
+  });
+});

--- a/tests/tearDownDb.js
+++ b/tests/tearDownDb.js
@@ -13,6 +13,9 @@ const tearDownDb = async () => {
   await db.answers.deleteMany();
   await db.$queryRaw`ALTER SEQUENCE "answers_answer_id_seq" RESTART WITH 1;`;
 
+  await db.commenttags.deleteMany();
+  await db.$queryRaw`ALTER SEQUENCE "commenttags_tag_id_seq" RESTART WITH 1;`;
+
   await db.comments.deleteMany();
   await db.$queryRaw`ALTER SEQUENCE "comments_id_seq" RESTART WITH 1;`;
 


### PR DESCRIPTION
#### What does this PR do?
— add controller to create and get tags `commentstags`

#### Where should the reviewer start?

> - app/controllers/comments/tags/create.js
> - app/controllers/comments/tags/list.js


#### How should this be manually tested?
1. Pull the new references to your local environment and start tracking the branch backend/add-list-tags-controller.
```
git pull;
git checkout --track origin/backend/add-list-tags-controller;
```
2. run the tests with the command
```
npm run test:integration
``` 

⚠️ Remember, you have to run the container of your test-database. See the Dockerfile to see the configuration

#### What are the relevant tickets?
(Link to issues, related PR, JIRA issues, etc.)
Closes #278 

#### Screenshots
(Screenshots of the feature if available.)
<img width="634" alt="Screen Shot 2023-09-18 at 19 12 50" src="https://github.com/wizeline/wize-q-remix/assets/97203617/3475ebb2-c1e7-4a98-ae6d-8df6e1add8bd">
