### PR TITLE
feat: modal to tag a comment

### DIFF
--- a/app/components/Atoms/Label/Label.jsx
+++ b/app/components/Atoms/Label/Label.jsx
@@ -11,7 +11,7 @@ function Label({ text, type, approvedBy }) {
       {approvedBy && (
       <Styled.ApproverName>
         by
-        <strong>{approvedBy}</strong>
+        <strong>{` ${approvedBy}`}</strong>
       </Styled.ApproverName>
       )}
     </Styled.LabelContainer>

--- a/app/components/Modals/TagsModal/TagModal.jsx
+++ b/app/components/Modals/TagsModal/TagModal.jsx
@@ -1,0 +1,83 @@
+/* eslint-disable camelcase */
+import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+import { useFetcher } from '@remix-run/react';
+import * as s from 'app/components/Modals/TagsModal/TagModal.styled';
+import { AiOutlineCloseCircle } from 'react-icons/ai';
+import Input from '../../Atoms/Input/Input';
+
+function TagModal({
+  onClose, selectTag, tag, removeTag,
+}) {
+  const fetcher = useFetcher();
+  const [textTag, setTexTag] = useState('');
+  const [tags, setTags] = useState([]);
+  const { id } = tag;
+
+  useEffect(() => {
+    const url = id ? `/?tagId=${id}` : '/';
+    fetcher.load(url);
+  }, []);
+
+  useEffect(() => {
+    if (fetcher.data && fetcher.data.tagslist) {
+      setTags(fetcher.data.tagslist.tags);
+    }
+  }, [fetcher.data]);
+
+  const onChange = (event) => {
+    setTexTag(event.target.value);
+    const url = id ? `/?tagId=${id}&searchtag=${event.target.value}` : `/?searchtag=${event.target.value}`;
+    fetcher.load(url);
+  };
+
+  return (
+    <s.Wrapper>
+      <s.Container>
+        <s.CloseBtn onClick={onClose}> X </s.CloseBtn>
+        <div>
+          <Input
+            type="text"
+            placeholder="Search for a tag"
+            onChange={(e) => onChange(e)}
+            value={textTag}
+          />
+          <div>
+            <h4>Select a tag for the comment</h4>
+            <s.TagContaniner>
+              {tags.length > 0 ? tags.map(({ tag_text, tag_id }) => (
+                <>
+                  <s.Tag key={`${tag_id}-tag`} onClick={() => { selectTag(tag_id); }} selected={tag_id === id}>
+                    {tag_text}
+                  </s.Tag>
+                  {tag_id === id && (
+                  <s.BtnRemoveTag onClick={removeTag}>
+                    <AiOutlineCloseCircle size="20px" />
+                  </s.BtnRemoveTag>
+                  )}
+
+                </>
+              )) : 'No tags...'}
+            </s.TagContaniner>
+          </div>
+        </div>
+      </s.Container>
+    </s.Wrapper>
+  );
+}
+
+TagModal.propTypes = {
+  onClose: PropTypes.func.isRequired,
+  selectTag: PropTypes.func.isRequired,
+  removeTag: PropTypes.func.isRequired,
+  tag: PropTypes.shape({
+    id: PropTypes.number,
+    text: PropTypes.string,
+  }),
+};
+
+TagModal.defaultProps = {
+  tag: null,
+};
+
+export default TagModal;

--- a/app/components/Modals/TagsModal/TagModal.styled.jsx
+++ b/app/components/Modals/TagsModal/TagModal.styled.jsx
@@ -1,0 +1,82 @@
+/* eslint-disable import/prefer-default-export */
+import styled, { css } from 'styled-components';
+
+export const Wrapper = styled.div`
+  background-color: rgba(0, 0, 0, 0.5);
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  width: 100%;
+  height: 100%;
+  transform: translate(-50%, -50%);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1050;
+`;
+
+export const Container = styled.div`
+  background-color: white;
+  padding: 24px;
+  max-width: 600px;
+  max-height: 600px;
+  width: 600px;
+  height: 300px;
+  border-radius: 12px;
+`;
+
+export const CloseBtn = styled.div`
+  float: right;
+  cursor: pointer;
+`;
+
+export const InputText = styled.input`
+  width: 100%;
+  margin: 8px 0px;
+  border-radius: 16px;
+  padding: 12px 20px;
+  border: none;
+  height: 100%;
+  background-color: transparent;
+
+`;
+
+export const TagContaniner = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+`;
+
+export const Tag = styled.div`
+  border: none;
+  padding: 12px 8px;
+  text-align: center;
+  box-shadow: 4px 4px 10px 0px var(--color-secondary);
+  border-radius: 16px;
+  margin: 4px;
+  &:hover {
+    background-color: var(--color-secondary);
+    cursor: pointer;
+    color: white;
+    box-shadow: none;
+  }
+  ${(props) => props.selected && css`
+    border-radius:16px 0px 0px 16px;
+    background-color: var(--color-secondary);
+    color: white;
+    box-shadow: none;
+    margin: 4px 0px 4px 4px;
+  `}
+`;
+
+export const BtnRemoveTag = styled.div`
+  display: flex;
+  align-items: center;
+  border-radius: 0px 16px 16px 0px;
+  margin: 4px 0px;
+  background-color: var(--color-secondary);
+  color: white;
+  svg {
+    width: 2em;
+  }
+  cursor: pointer;
+`;

--- a/app/components/Modals/TagsModal/index.js
+++ b/app/components/Modals/TagsModal/index.js
@@ -1,0 +1,1 @@
+export { default } from 'app/components/Modals/TagsModal/TagModal';

--- a/app/components/QuestionComment/QuestionComment.styled.jsx
+++ b/app/components/QuestionComment/QuestionComment.styled.jsx
@@ -256,3 +256,10 @@ export const ApproverName = styled.span`
   font-size: 12px;
   color: var(--color-green);
 `;
+
+export const Tag = styled.div`
+  border: 1px solid #B4B4B4;
+  padding: 8px;
+  border-radius: 8px;
+  color: #B4B4B4;
+`;

--- a/app/controllers/comments/list.js
+++ b/app/controllers/comments/list.js
@@ -59,13 +59,17 @@ const listComments = async (params) => {
   Approver.full_name AS "ApproverFull_name",
   Approver.is_admin AS "ApproverIs_admin",
   Approver.profile_picture AS "ApproverProfile_picture",
-  Approver.job_title AS "ApproverJob_title"
+  Approver.job_title AS "ApproverJob_title",
+  tag.tag_id as "tagId", 
+  tag.tag_text as "tagText" 
 FROM
   "comments" AS cmts
 LEFT JOIN
   "users" AS "User" ON cmts."useremail" = "User".email
 LEFT JOIN
   "users" AS Approver ON cmts."approvedby" = Approver.employee_id
+LEFT JOIN 
+  "commenttags" AS tag ON cmts.tag_id = tag.tag_id 
 WHERE
   cmts."questionid" = ${questionId}
  ${sortBy === 'votes' ? Prisma.sql`ORDER BY cmts.approvedby ASC, votes DESC, recent_activity DESC` : Prisma.sql`ORDER BY cmts.approvedby ASC, recent_activity DESC`}

--- a/app/controllers/comments/tags/list.js
+++ b/app/controllers/comments/tags/list.js
@@ -11,22 +11,41 @@ const whereSearchTerm = (searchTerm) => {
   };
 };
 
-const buildWhere = (searchTerm) => {
+const whereNotID = (id) => {
+  if (!id) { return {}; }
+
+  return {
+    NOT: [{
+      tag_id: id,
+    }],
+  };
+};
+
+const buildWhere = (searchTerm, id) => {
   const where = {
     ...whereSearchTerm(searchTerm),
+    ...whereNotID(id),
   };
   return where;
 };
 
-const ListTags = async (params) => {
-  const { searchTerm, limit, offset } = params;
+const listTags = async (params) => {
+  const {
+    searchTerm, limit, offset, id,
+  } = params;
   const tags = await db.commenttags.findMany({
-    where: buildWhere(searchTerm),
+    where: buildWhere(searchTerm, parseInt(id, 10)),
     take: limit || DEFAULT_TAGS_LIMIT,
     skip: offset || 0,
   });
 
-  return { tags };
+  let tagByID;
+  if (id) {
+    tagByID = await db.commenttags.findUnique({
+      where: { tag_id: parseInt(id, 10) },
+    });
+  }
+  return { tags: [tagByID, ...tags].filter((tag) => tag !== undefined) };
 };
 
-export default ListTags;
+export default listTags;

--- a/app/root.jsx
+++ b/app/root.jsx
@@ -20,6 +20,7 @@ import { commitSession, getAuthenticatedUser, getSession } from 'app/session.ser
 import AppNavbar from 'app/components/AppNavbar';
 import listQuestions from 'app/controllers/questions/list';
 import listUsers from 'app/controllers/users/list';
+import listTags from 'app/controllers/comments/tags/list';
 
 const titleSuffix = process.env.NODE_ENV === 'development' ? ' - Local' : '';
 
@@ -46,6 +47,8 @@ export const loader = async ({ request }) => {
   const url = new URL(request.url);
   const search = url.searchParams.get('search');
   const userSearch = url.searchParams.get('userSearch');
+  const searchTag = url.searchParams.get('searchtag');
+  const tagId = url.searchParams.get('tagId');
 
   let searchResults = [];
 
@@ -56,6 +59,7 @@ export const loader = async ({ request }) => {
       search,
     });
   }
+  const tagslist = await listTags({ searchTerm: searchTag, offset: 0, id: tagId });
 
   const globalSuccess = session.get('globalSuccess') || null;
 
@@ -65,6 +69,7 @@ export const loader = async ({ request }) => {
       globalSuccess,
       searchResults,
       searchUsers: userSearch ? (await listUsers({ search: userSearch, size: 5 })).users : [],
+      tagslist,
     },
     {
       headers: {

--- a/app/routes/questions/$questionId.jsx
+++ b/app/routes/questions/$questionId.jsx
@@ -33,6 +33,7 @@ import assignQuestion from 'app/controllers/questions/assignQuestion';
 import listDepartments from 'app/controllers/departments/list';
 import deleteNPS from 'app/controllers/answers/nps/delete';
 import modifyEnabledValue from 'app/controllers/questions/modifyEnableStatus';
+import taggingComment from 'app/controllers/comments/tags/tagging.js';
 
 const replacer = (key, value) => (typeof value === 'bigint' ? value.toString() : value);
 
@@ -172,6 +173,14 @@ export const action = async ({ request }) => {
       const params = JSON.parse(formData.get('params'));
       params.employeeid = user.employee_id;
       response = await approvedByComment(params);
+      break;
+    case ACTIONS.TAGGING_COMMENT:
+      const { tagId, commentId } = JSON.parse(formData.get('data'));
+      response = await taggingComment({
+        tagId,
+        commentId,
+        taggedBy: tagId ? user.employee_id.toString() : null,
+      });
       break;
     default:
       break;

--- a/app/utils/actions.js
+++ b/app/utils/actions.js
@@ -17,6 +17,7 @@ const ACTIONS = {
   UPDATE_DEPARTMENT: 'update_department',
   ADD_EMPLOYEE_TO_DEPARTMENT: 'add_employee_to_department',
   REMOVE_EMPLOYEE_TO_DEPARTMENT: 'remove_employee_to_department',
+  TAGGING_COMMENT: 'tagging_a_comment',
 };
 
 export default ACTIONS;


### PR DESCRIPTION
#### What does this PR do?
- adds the feature to tag a comment, this option is only available for admins. 

#### How should this be manually tested?
1. Pull the new references to your local environment and start tracking the branch frontend/commenttags.
```
git pull;
git checkout --track origin/frontend/commenttags;
```
2 run the project
```
npm run dev
```
3. Insert some data in the table `INSERT INTO wizeq.commenttags (tag_text)  values ('violate guidelines');`
5. Double check that you have admins permissions. 
6. Log in and go to the details of a question with comments 
7. Click to the icon <img width="27" alt="Screen Shot 2023-09-22 at 17 06 42" src="https://github.com/wizeline/wize-q-remix/assets/97203617/5477c910-f5d5-42e8-987c-ea0e4e538abc"> (this is going to show a modal) 
8. You can select a tag, change the existing one or remove it. 
9. :tada:



#### What are the relevant tickets?
(Link to issues, related PR, JIRA issues, etc.)
Closes #269 

#### Screenshots
:camera:  

https://github.com/wizeline/wize-q-remix/assets/97203617/3bb03545-342d-488c-8f28-f38546a88097
