### PR TITLE
fix: filter status

### DIFF
--- a/app/components/CustomDropdown/CustomDropdown.Styled.jsx
+++ b/app/components/CustomDropdown/CustomDropdown.Styled.jsx
@@ -111,3 +111,8 @@ export const CMenuItem = styled(MenuItem)`
     }
   }
 `;
+
+export const CDNote = styled.p`
+  font-size: 12px;
+  color:gray;
+`;

--- a/app/components/CustomDropdown/CustomDropdown.jsx
+++ b/app/components/CustomDropdown/CustomDropdown.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { AiOutlineWarning } from 'react-icons/ai';
 import * as Styled from './CustomDropdown.Styled';
 
 function CustomDropdown(props) {
@@ -43,6 +44,12 @@ function CustomDropdown(props) {
       <Styled.CDropdown.Menu className={props.menuClass}>
         {props.elements.length > 0
           && renderElements(props.elements)}
+        { props.higlihNote && (
+        <Styled.CDNote>
+          <AiOutlineWarning />
+          {props.higlihNote}
+        </Styled.CDNote>
+        )}
       </Styled.CDropdown.Menu>
     </Styled.CDropdown>
   );
@@ -64,6 +71,7 @@ CustomDropdown.propTypes = {
   showSelected: PropTypes.bool,
   accessValueName: PropTypes.string.isRequired,
   disabled: PropTypes.bool,
+  higlihNote: PropTypes.string,
 };
 
 CustomDropdown.defaultProps = {
@@ -76,6 +84,7 @@ CustomDropdown.defaultProps = {
   isHighlighted: false,
   showSelected: true,
   disabled: false,
+  higlihNote: null,
 };
 
 export default CustomDropdown;

--- a/app/components/Filters/Filters.jsx
+++ b/app/components/Filters/Filters.jsx
@@ -25,6 +25,7 @@ import {
   LOCATION_ACCESS_VALUE,
   TEXT_BUTTON,
   DEFAULT_LOCATION_OPT,
+  SHOW_ONLY_OFFICIAL_ANSWER,
 } from 'app/utils/constants';
 import Button from 'app/components/Atoms/Button';
 import CustomDropdown from 'app/components/CustomDropdown';
@@ -233,6 +234,7 @@ function Filters(props) {
     selectedValue: selectedStatus.value,
     isHihlighted: selectedStatus !== DEFAULT_STATUS_OPT,
     accessValueName: STATUS_ACCESS_VALUE,
+    higlihNote: SHOW_ONLY_OFFICIAL_ANSWER,
   };
 
   return (

--- a/app/utils/constants.js
+++ b/app/utils/constants.js
@@ -263,6 +263,7 @@ export const NO_COLLABORATOR_SELECTED_TOOLTIP_MESSAGE = 'Select a collaborator';
 export const MIN_CHARS_QUESTION_INPUT_TOOLTIP_MESSAGE = inputPlaceholder(MINIMUM_QUESTION_LENGTH);
 export const DEFAULT_MESSAGE_END_QUESTION_INPUT_TOOLTIP = 'to ask a question.';
 export const NO_LOCATIONS_AVAILABLE_TOOLTIP_MESSAGE = 'There are no locations';
+export const SHOW_ONLY_OFFICIAL_ANSWER = '"Answered" option filters only admins answers (official and comment approved)';
 
 // Sockets & Reactivity
 export const FAKE_SOCKET = {

--- a/tests/integration/controllers/questions/listQuestion.test.js
+++ b/tests/integration/controllers/questions/listQuestion.test.js
@@ -213,7 +213,11 @@ describe('listQuestions', () => {
     });
 
     it('returns questions that have been answered', () => {
-      expect(response.length).toEqual(2);
+      expect(response.length).toEqual(4);
+    });
+
+    it('returns a question with a comment approved by an admin', () => {
+      expect(response[1].question_id).toEqual(8);
     });
   });
 
@@ -235,7 +239,7 @@ describe('listQuestions', () => {
     });
 
     it('returns questions that have not been answered', () => {
-      expect(response.length).toEqual(6);
+      expect(response.length).toEqual(4);
     });
   });
 


### PR DESCRIPTION
#### What does this PR do?
- add the option to filter the questions depending on the answer that they have. 
   - answered:  official answer and comment approved by an admin. 
   - not answered: not an official answer and community answer. 
   
#### Where should the reviewer start?
-  Go to the list controller inside question folder. 
- Run test with `npm run test:integration`


#### How should this be manually tested?
1. Pull the new references to your local environment and start tracking the branch fix-filter-status.
```
git pull;
git checkout --track origin/fix-filter-status;
```

2. Run the application. 
```
npm run dev
```

3. In the home page, filter by status and verify that the results are correct.


#### What are the relevant tickets?
(Link to issues, related PR, JIRA issues, etc.)
Closes #283 

#### Screenshots

https://github.com/wizeline/wize-q-remix/assets/97203617/7617eae5-e9ed-402a-895a-88b1793f7358

<img width="322" alt="Screen Shot 2023-10-13 at 14 13 29" src="https://github.com/wizeline/wize-q-remix/assets/97203617/21cbf09a-092a-4be1-ae74-79f5b283145e">

