### PR TITLE
fix: improve openai embeddings error handling

### DIFF
--- a/app/controllers/embeddings/create.js
+++ b/app/controllers/embeddings/create.js
@@ -3,7 +3,7 @@ import { instantiateOpenAi, requestEmbedding } from 'app/utils/openai';
 
 const upsertQuestionEmbedding = async (questionId, answer) => {
   const openai = instantiateOpenAi();
-  const { data } = await requestEmbedding(openai, [answer]);
+  const { data } = (await requestEmbedding(openai, [answer])) || {};
   const embeddings = data?.map((obj) => obj.embedding);
   const embedding = (embeddings && embeddings.length > 0) ? embeddings[0] : null;
 

--- a/app/utils/openai/index.js
+++ b/app/utils/openai/index.js
@@ -3,21 +3,30 @@ const { EMBEDDINGS_MODEL } = require('../constants');
 
 const API_KEY = process.env.OPENAI_API_KEY;
 
-const instantiateOpenAi = () => (API_KEY ? new OpenAI({
-  apiKey: API_KEY,
-}) : undefined);
+const instantiateOpenAi = () => {
+  const instance = API_KEY ? new OpenAI({
+    apiKey: API_KEY,
+  }) : undefined;
 
+  return instance;
+};
 const requestEmbedding = async (instance, prompts) => {
   if (!instance) {
-    return {};
+    return undefined;
   }
 
-  const embeddings = await instance.embeddings.create({
-    model: EMBEDDINGS_MODEL,
-    input: prompts,
-  });
+  try {
+    const embeddings = await instance.embeddings.create({
+      model: EMBEDDINGS_MODEL,
+      input: prompts,
+    });
 
-  return embeddings;
+    return embeddings;
+  } catch (error) {
+    /* eslint-disable no-console */
+    console.error(error);
+    return undefined;
+  }
 };
 
 module.exports = {

--- a/tests/unit/utils/openai/embeddings.test.js
+++ b/tests/unit/utils/openai/embeddings.test.js
@@ -6,7 +6,7 @@ describe('requestEmbedding', () => {
 
   it('returns empty object when openai instance is not defined', async () => {
     const results = await requestEmbedding(undefined, prompts);
-    expect(results).toEqual({});
+    expect(results).toBeUndefined();
   });
 
   it('calls openai with prompts and established model', async () => {


### PR DESCRIPTION
#### What does this PR do?
- Fixes crash on answer creation caused by openai embeddings implementation.

#### How should this be manually tested?
1. Set your OPENAI_API_KEY in .env to "undefined" (this is temporarily the current value in develop and prod environments)
2. Create an answer for any question and verify the console error is ooutput, but it doesn't crash the app.
