### PR TITLE
feat: Add feature flag for enabling/disabling anonymous question posting

### DIFF
--- a/app/components/QuestionForm/QuestionForm.jsx
+++ b/app/components/QuestionForm/QuestionForm.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import { ContentState, convertFromRaw, EditorState } from 'draft-js';
 import { markdownToDraft } from 'markdown-draft-js';
 import { RiArrowRightSFill } from 'react-icons/ri';
-import { requireEmployeeAssigned } from 'app/config/flags.json';
+import { requireEmployeeAssigned, postAnonymousQuestions } from 'app/config/flags.json';
 
 import {
   DEFAULT_LOCATION,
@@ -321,6 +321,7 @@ function QuestionForm({
             onInputChange={onInputChange}
             submitElement={(
               <Styled.Submit disabled={askBtnClass}>
+                { postAnonymousQuestions && (
                 <p style={{ float: 'left' }}>
                   <span>Ask anonymously</span>
                   <Switch
@@ -328,6 +329,7 @@ function QuestionForm({
                     onChange={onAnonymousChange}
                   />
                 </p>
+                )}
                 <InputCounter
                   currentLength={getQuestionLength(state.inputValue)}
                   maxLength={MAXIMUM_QUESTION_LENGTH}

--- a/app/config/flags.json
+++ b/app/config/flags.json
@@ -5,5 +5,6 @@
   "sendEmailOnQuestionReassigned": true,
   "sendManagersEmailReminder": true,
   "sendEmployeesEmailReminder": true,
-  "requestEmbeddingOnAnswer": true
+  "requestEmbeddingOnAnswer": true,
+  "postAnonymousQuestions": false
 }


### PR DESCRIPTION
#### What does this PR do?
introduces a new feature flag named `postAnonymousQuestions` that allows toggling the ability to post questions anonymously. The flag is implemented to control the visibility of the anonymousposting feature, giving flexibility to enable or disable it.

#### Where should the reviewer start?
- verify that the `postAnonymousQuestions` is `false`

#### How should this be manually tested?

1. Log in.
2. Navigate to the page to create a new question (click on 'Ask Question').
3. Ensure that you do not see the option to post an anonymous question.
4. Create a question.
5. Open the file `` and modify the value of `postAnonymousQuestions` to true.
6. Repeat step 2.
7. You should now see the option to post anonymous questions.
8. Create a question (both anonymous and non-anonymous).

#### Any background context you want provide?
we want to temporary restrict the option to post anonymous questions. 

#### What are the relevant tickets?
Closes #291 

#### Screenshots

[feature flag: ` postAnonymousQuestions : false` ]
<img width="828" alt="Screen Shot 2023-12-13 at 12 48 27" src="https://github.com/wizeline/wize-q-remix/assets/97203617/88062858-88e0-480b-a1f1-fa3b91d14653">


[feature flag: ` postAnonymousQuestions : true` ]

<img width="824" alt="Screen Shot 2023-12-13 at 12 49 44" src="https://github.com/wizeline/wize-q-remix/assets/97203617/366458ed-8a34-45c6-898c-052483b49698">
