### PR TITLE
feat: Change toast notification to a popup when user creates anonymous question

### DIFF
--- a/app/components/Modals/AlertAnonQuestions/AlertAnonQuestions.jsx
+++ b/app/components/Modals/AlertAnonQuestions/AlertAnonQuestions.jsx
@@ -6,6 +6,7 @@ import {
   CLOSE_BUTTON,
   SECONDARY_BUTTON,
   PRIMARY_BUTTON,
+  COPIED_LINK_MESSAGE,
 } from 'app/utils/constants';
 import { useRef, useState } from 'react';
 
@@ -61,7 +62,13 @@ function AlertAnonQuestions({
           </s.LinkContainer>
         </s.ModalBody>
         <s.ModalFooter>
-          { showCopyMessage && <p style={{ color: 'green' }}> The link copied succesfully  </p>}
+          { showCopyMessage && (
+          <p style={{ color: 'green' }}>
+            {' '}
+            {COPIED_LINK_MESSAGE}
+            {' '}
+          </p>
+          )}
           <Button type="button" category={SECONDARY_BUTTON} onClick={onClose}>
             Cancel
           </Button>

--- a/app/components/Modals/AlertAnonQuestions/AlertAnonQuestions.jsx
+++ b/app/components/Modals/AlertAnonQuestions/AlertAnonQuestions.jsx
@@ -1,0 +1,85 @@
+/* eslint-disable camelcase */
+import PropTypes from 'prop-types';
+import * as s from 'app/components/Modals/AlertAnonQuestions/AlertAnonQuestions.styled';
+import Button from 'app/components/Atoms/Button';
+import {
+  CLOSE_BUTTON,
+  SECONDARY_BUTTON,
+  PRIMARY_BUTTON,
+} from 'app/utils/constants';
+import { useRef, useState } from 'react';
+
+function AlertAnonQuestions({
+  onClose,
+  data,
+}) {
+  const parrafoRef = useRef();
+  const [showCopyMessage, setShowCopyMessage] = useState(false);
+  const { message, questionUrl } = data;
+
+  const copyLink = () => {
+    if (parrafoRef.current) {
+      const seleccion = window.getSelection();
+      const rango = document.createRange();
+      rango.selectNodeContents(parrafoRef.current);
+      seleccion.removeAllRanges();
+      seleccion.addRange(rango);
+
+      document.execCommand('copy');
+      seleccion.removeAllRanges();
+      setShowCopyMessage(true);
+
+      setTimeout(() => {
+        setShowCopyMessage(false);
+      }, 3000);
+    }
+  };
+
+  return (
+    <s.Modal>
+      <s.ModalDialog>
+        <s.ModalHeader>
+          <Button category={CLOSE_BUTTON} onClick={onClose} />
+        </s.ModalHeader>
+        <s.ModalBody>
+          <s.WarningContainer>
+            <s.WarningIcon />
+            <s.Warnings>
+              <h4>
+                {' '}
+                {message}
+                {' '}
+              </h4>
+            </s.Warnings>
+          </s.WarningContainer>
+          <s.LinkContainer>
+            <p ref={parrafoRef}>
+              <a href={questionUrl}>
+                {questionUrl}
+              </a>
+            </p>
+          </s.LinkContainer>
+        </s.ModalBody>
+        <s.ModalFooter>
+          { showCopyMessage && <p style={{ color: 'green' }}> The link copied succesfully  </p>}
+          <Button type="button" category={SECONDARY_BUTTON} onClick={onClose}>
+            Cancel
+          </Button>
+          <Button type="button" category={PRIMARY_BUTTON} onClick={() => copyLink()}>
+            Copy Link
+          </Button>
+        </s.ModalFooter>
+      </s.ModalDialog>
+    </s.Modal>
+  );
+}
+
+AlertAnonQuestions.propTypes = {
+  onClose: PropTypes.func.isRequired,
+  data: PropTypes.shape({
+    message: PropTypes.string,
+    questionUrl: PropTypes.string,
+  }).isRequired,
+};
+
+export default AlertAnonQuestions;

--- a/app/components/Modals/AlertAnonQuestions/AlertAnonQuestions.styled.jsx
+++ b/app/components/Modals/AlertAnonQuestions/AlertAnonQuestions.styled.jsx
@@ -1,0 +1,110 @@
+/* eslint-disable import/prefer-default-export */
+import styled from 'styled-components';
+import { MdErrorOutline } from 'react-icons/md';
+
+export const Modal = styled.div` 
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 1050;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    background-color: rgba(0, 0, 0, 0.5);
+`;
+
+export const ModalDialog = styled.div`
+    position: relative;
+    border-radius: 5px;
+    border: 0;
+    background-color: #fff;
+    box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.5);
+    overflow: hidden;
+    margin: 0 auto;
+    width: 100%;
+    display: block;
+    max-height: calc(100vh - 150px);
+    overflow-y: auto;
+    padding: 0px 24px;
+    max-width: 55vw;
+    @media (max-width: 768px) {
+        max-width: 80vw;
+    }
+    @media (max-width: 576px) {
+        max-height: 100%;
+        max-width: 100%;
+        height: 100%;
+    }
+`;
+
+export const ModalFooter = styled.div`
+    border-top: none;
+    background-color: #fff;
+    border-bottom: none;
+    padding: 15px;
+    text-align: right;
+    box-sizing: border-box;
+    display: block;
+    font-size: 14px;
+    ${(props) => (props.variant === 'logout' ? 'border-top: 1px solid #e5e5e5;padding: 15px;text-align: right;' : 'border-bottom: none;')}
+`;
+
+export const ModalHeader = styled.div`
+    overflow-y: hidden;
+    padding: 15px;
+    box-sizing: border-box;
+    display: block;
+    font-size: 14px;
+    ${(props) => (props.variant === 'logout' ? 'border-bottom: 1px solid #e5e5e5;padding: 15px;' : 'border-bottom: none;')}
+`;
+
+export const ModalBody = styled.div`
+  float: right;
+  cursor: pointer;
+`;
+
+export const WarningContainer = styled.div`
+  display: flex;
+  gap: 10px;
+  border-radius: 5px;
+  background-color: #F8E9B7;
+  color: #9f640b;
+  justify-content: space-evenly;
+  width: 80%;
+  margin: 0 auto;
+  align-items: center;
+  padding: 15px;
+  box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.5);
+  @media (max-width: 768px) {
+    width: 90%;
+  }
+  @media (max-width: 576px) {
+    width: 100%;
+  }
+`;
+
+export const WarningIcon = styled(MdErrorOutline)`
+  font-size: 5rem;
+`;
+
+export const Warnings = styled.div`
+  list-style-type: none;
+  margin: 0;
+  text-align: left;
+  padding: 3px;
+  p {
+    margin: 0;
+    font-size: 1.5rem;
+  }
+`;
+
+export const LinkContainer = styled.div`
+text-align: center;
+font-size: 1.5rem;
+padding-top: 20px;
+`;

--- a/app/components/Modals/AlertAnonQuestions/index.js
+++ b/app/components/Modals/AlertAnonQuestions/index.js
@@ -1,0 +1,1 @@
+export { default } from 'app/components/Modals/AlertAnonQuestions/AlertAnonQuestions';

--- a/app/components/Modals/ValuesMessageModal/ValuesMessageModal.jsx
+++ b/app/components/Modals/ValuesMessageModal/ValuesMessageModal.jsx
@@ -26,46 +26,42 @@ function ValuesMessageModal({ show, onClose }) {
               {' '}
               !
             </styled.ModalTitle>
-            <styled.ModalSubtitle>
-              Welcome to Wize Q!
-            </styled.ModalSubtitle>
           </styled.ModalHeader>
           <styled.ModalBody>
             <p>
-              We want to share a few simple guidelines before you start.
-              Remember that Wize Q is a space for asking questions and providing answers that
-              are helpful to our community.
+              Welcome to Wize Q.
+              This is a space for asking questions and providing answers
+              that are helpful to our community. Before you get started,
+              please remember to practice our values when using the platform
             </p>
-            <p>Please practice our values when using Wize Q: </p>
             <styled.ValuesInformation>
               <p>
                 {renderBulletPoint('var(--color-primary)')}
                 <styled.ValueText color="var(--color-primary)">Ownership</styled.ValueText>
-                – See if you can find the answer to your question before posting on Wize Q.
-                And if you know the answer to a question or how to find it,
-                be sure to reply — anyone can!
+                <br />
+                - Before posting, check if the answer is already available in other channels.
+                Additionally, if you know the answer to a question from another Wizeliner,
+                be sure to respond.
               </p>
               <p>
                 {renderBulletPoint('var(--color-secondary)')}
                 <styled.ValueText color="var(--color-secondary)">Innovation</styled.ValueText>
-                – When someone shares a concern or challenge,
-                let’s be innovative — propose a solution or offer support!
+                <br />
+                - If someone shares a concern or challenge, try to propose a solution!
               </p>
               <p>
                 {renderBulletPoint('#E5C8A6')}
                 <styled.ValueText color="#E5C8A6">Community</styled.ValueText>
-                – Remember to treat everyone with dignity and respect.
-                Assume others have good intentions. Always be honest and constructive.
-                Let’s make Wizeline a community where everyone can thrive.
+                <br />
+                - Treat everyone with dignity and respect,
+                be honest and constructive, and always assume others have good intentions.
               </p>
             </styled.ValuesInformation>
             <p>
-              Consider that other channels:
-              (ticketing portal, Slack, your TPLs or people partner)
-              might be more effective for finding the right answer quickly.
+              For more detailed guidelines, please see  Wize Q’s home page.
             </p>
             <p>Thanks for being a valuable contributor to our community! </p>
-            <p>The Wize Q Team</p>
+            <strong><p>The Wize Q Team</p></strong>
           </styled.ModalBody>
           <styled.ModalFooter>
             <Button

--- a/app/components/Notifications/Notifications.jsx
+++ b/app/components/Notifications/Notifications.jsx
@@ -20,10 +20,9 @@ function Notifications() {
     if (globalSuccess) {
       const { message, questionUrl } = globalSuccess;
       if (questionUrl) {
-        toast.success(successAnonMessage(message, questionUrl), QUESTION_CREATED_TOAST_CONFIG);
-      } else {
-        toast.success(message, DEFAULT_TOAST_CONFIG);
+        return;
       }
+      toast.success(message, DEFAULT_TOAST_CONFIG);
     }
     if (!data) return;
 

--- a/app/components/QuestionDetail/QuestionDetail.jsx
+++ b/app/components/QuestionDetail/QuestionDetail.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable camelcase */
-import React, { useState, useRef } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import { useSubmit, useTransition, useSearchParams } from '@remix-run/react';
 import { useParams } from 'react-router-dom';
 import PropTypes from 'prop-types';
@@ -31,6 +31,7 @@ import Loader from 'app/components/Loader';
 import logomark from 'app/images/logomark_small.png';
 import useUser from 'app/utils/hooks/useUser';
 import ACTIONS from 'app/utils/actions';
+import AlertAnonQuestions from '../Modals/AlertAnonQuestions';
 
 function QuestionDetails(props) {
   const submit = useSubmit();
@@ -40,12 +41,13 @@ function QuestionDetails(props) {
   const isAdmin = profile.is_admin;
   const currentUserEmail = profile.email;
 
-  const { question } = props;
+  const { question, newQuestionAlert } = props;
 
   const initialState = {
     showAnswerModal: false,
     showAssignAnswerModal: false,
     showDeleteAnswerModal: false,
+    showAlertAnonQuestion: newQuestionAlert.isNewQuestion,
   };
 
   const [state, setState] = useState(initialState);
@@ -146,6 +148,10 @@ function QuestionDetails(props) {
     setState({ ...state, showDeleteAnswerModal: false });
   };
 
+  const handleAlertAnonQuestion = () => {
+    setState({ ...state, showAlertAnonQuestion: false });
+  };
+
   const answerModal = state.showAnswerModal ? (
     <AnswerModal
       question={question}
@@ -159,6 +165,10 @@ function QuestionDetails(props) {
       question={question}
       onClose={handleDeleteAnswerModalClose}
     />
+  ) : null;
+
+  const showAnonQuestionAlert = (state.showAlertAnonQuestion && newQuestionAlert.data !== null) ? (
+    <AlertAnonQuestions onClose={handleAlertAnonQuestion} data={newQuestionAlert.data} />
   ) : null;
 
   const scoreAnswer = (score, answer_id) => {
@@ -297,6 +307,7 @@ function QuestionDetails(props) {
       {answerModal}
       {deleteAnswerModal}
       {assignAnswerModal}
+      {showAnonQuestionAlert}
     </Styled.Container>
   );
 }
@@ -333,10 +344,18 @@ QuestionDetails.propTypes = {
     hasLike: PropTypes.bool.isRequired,
     hasDislike: PropTypes.bool.isRequired,
   }),
+  newQuestionAlert: PropTypes.shape({
+    isNewQuestion: PropTypes.bool,
+    data: PropTypes.shape(),
+  }),
 };
 
 QuestionDetails.defaultProps = {
   question: null,
+  newQuestionAlert: {
+    isNewQuestion: false,
+    data: null,
+  },
 };
 
 export default QuestionDetails;

--- a/app/components/QuestionForm/QuestionForm.jsx
+++ b/app/components/QuestionForm/QuestionForm.jsx
@@ -20,7 +20,6 @@ import {
   NO_LOCATIONS_AVAILABLE_TOOLTIP_MESSAGE,
   NONE_LOCATION,
   DEFAULT_LOCATION_MESSAGE,
-  ALL_LOCATIONS_MESSAGE,
   LOCATION_WARNING,
   NO_DEPARTMENT_SELECTED_ID,
   NOT_ASSIGNED_DEPARTMENT_ID,
@@ -150,10 +149,8 @@ function QuestionForm({
       isAsking: true,
     });
 
-    if (location === NONE_LOCATION) {
+    if (location === NONE_LOCATION || location === DEFAULT_LOCATION) {
       warningsToShow.push(DEFAULT_LOCATION_MESSAGE);
-    } else if (location === DEFAULT_LOCATION) {
-      warningsToShow.push(ALL_LOCATIONS_MESSAGE);
     } else {
       const prelocation = locations.find(
         (loc) => loc.code === location,

--- a/app/components/SubmitWithModal/SubmitWithModal.jsx
+++ b/app/components/SubmitWithModal/SubmitWithModal.jsx
@@ -7,6 +7,7 @@ import {
   SECONDARY_BUTTON,
   DANGER_BUTTON,
   CLOSE_BUTTON,
+  ANONYMOUS_QUESTION_WARNING,
 } from 'app/utils/constants';
 import useUser from 'app/utils/hooks/useUser';
 import Button from 'app/components/Atoms/Button';
@@ -24,7 +25,7 @@ function SubmitWithModal(props) {
   };
 
   const renderIdentityWarning = () => {
-    let identityMessage = IDENTITY_MESSAGE;
+    let identityMessage = isAnonymous ? ANONYMOUS_QUESTION_WARNING : IDENTITY_MESSAGE;
     let usernameTag = '';
 
     if (!isAnonymous) {

--- a/app/controllers/questions/create.js
+++ b/app/controllers/questions/create.js
@@ -56,7 +56,7 @@ const createQuestion = async (
     const questionDetailUrl = getQuestionDetailUrl(created.question_id);
 
     successMessage = {
-      message: 'The anonymous question has been created succesfully!\n\nPlease save the attached link for followup on answers: ',
+      message: 'Your anonymous question has been successfully created. Please save the link below to track responses to your post: ',
       questionUrl: questionDetailUrl,
     };
 

--- a/app/routes/questions/new.jsx
+++ b/app/routes/questions/new.jsx
@@ -4,8 +4,7 @@ import { json, redirect } from '@remix-run/node';
 import { useLoaderData, useSubmit } from '@remix-run/react';
 import * as Styled from 'app/styles/CreateQuestion.Styled';
 import Slogan from 'app/components/Slogan';
-import { MAXIMUM_QUESTION_LENGTH, MINIMUM_ANSWER_LENGTH } from 'app/utils/constants';
-import { RECOMMENDATIONS_QUESTION } from 'app/utils/constants';
+import { MAXIMUM_QUESTION_LENGTH, MINIMUM_ANSWER_LENGTH, RECOMMENDATIONS_QUESTION } from 'app/utils/constants';
 import QuestionForm from 'app/components/QuestionForm';
 import listLocations from 'app/controllers/locations/list';
 import {
@@ -51,6 +50,7 @@ export const action = async ({ request }) => {
     const session = await getSession(request);
     const { question, successMessage } = response;
     session.flash('globalSuccess', successMessage);
+    session.set('newQuestion', successMessage.questionUrl);
     const destination = `/questions/${question.question_id}`;
 
     return redirect(destination, {

--- a/app/utils/constants.js
+++ b/app/utils/constants.js
@@ -27,6 +27,8 @@ export const IDENTITY_MESSAGE = 'You are about to post a question';
 export const CONTINUE_MESSAGE = 'Do you want to continue?';
 export const CONTACT_WARNING = 'Please enter all fields';
 export const HTML_CODE_WARNING = 'Your input contains some HTML code without the correct Markdown format, so it will be removed if submitted. If you want to keep the HTML code please encapsulate it like `<html>markup</html>`';
+export const ANONYMOUS_QUESTION_WARNING = `You are about to post an anonymous question.
+This question will be posted privately and will only be visible to leadership and the site's moderators.`;
 
 export const PAGE_QUESTIONS_LIMIT = 20;
 export const PAGE_COMMENTS_LIMIT = 100;
@@ -284,7 +286,7 @@ export const MIN_QUESTION_PREVIEW_LENGTH = 13;
 export const QUESTION_BEING_PROCESSED = 'Your question is being processed';
 export const DEPARTMENT_WARNING = 'You need to select a department';
 export const EMPLOYEE_WARNING = 'You need to select a collaborator';
-export const DEFAULT_LOCATION_MESSAGE = 'As you have not selected a location for your question, it will be posted to all locations.';
+export const DEFAULT_LOCATION_MESSAGE = 'This question is not tagged to any specific location. Are you sure?';
 export const ALL_LOCATIONS_MESSAGE = 'This question will be posted to all locations. Are you sure?';
 export const LOCATION_WARNING = 'This question will be posted to: ';
 export const EMPLOYEE_PLACEHOLDER = 'Select a collaborator';

--- a/app/utils/constants.js
+++ b/app/utils/constants.js
@@ -359,3 +359,6 @@ export const DEFAULT_TAGS_LIMIT = 5;
 
 // OPENAI
 export const EMBEDDINGS_MODEL = 'text-embedding-ada-002';
+
+// MESSAGES
+export const COPIED_LINK_MESSAGE = 'The link was copied succesfully';


### PR DESCRIPTION
#### What does this PR do?
- Show a modal to inform the users, that they have to copy the link, after they created an anonymous question.


#### How should this be manually tested?

1. Login
2. Create an anonymous question
3. Verify that you can see the new modal and that you can copy the link using the button for that action
4. Create a question as normal user and verify that you can see the normal toast alert. 
5. :tada:

#### Any background context you want to provide?
This change was a requirement after the session that we have with the stakeholder. 

#### What are the relevant tickets?
(Link to issues, related PR, JIRA issues, etc.)
Closes #x

#### Screenshots

<img width="1001" alt="Screen Shot 2024-01-04 at 23 05 37" src="https://github.com/wizeline/wize-q-remix/assets/97203617/9ed48d87-0c9f-4504-ad15-74fa095218ad">

<img width="1020" alt="Screen Shot 2024-01-04 at 23 09 44" src="https://github.com/wizeline/wize-q-remix/assets/97203617/ec666fb2-2ebe-4901-b646-cc9ae2362aeb">


https://github.com/wizeline/wize-q-remix/assets/97203617/5d4d30e6-321e-496c-810b-2c37966d0f28

