### PR TITLE
fix: post the answer for anon question when is public. 

### DIFF
--- a/app/controllers/answers/create.js
+++ b/app/controllers/answers/create.js
@@ -54,11 +54,12 @@ const createAnswer = async (body, config = {
     },
   });
 
-  if (config.sendSlackOnAnswerCreation && relatedQuestion.is_public) {
+  if (config.sendSlackOnAnswerCreation) {
     slack.createAnswerNotification({
       questionId: relatedQuestion.question_id,
       questionBody: stripNewLines(relatedQuestion.question),
       answerBody: answer.answer_text,
+      is_public: relatedQuestion.is_public,
     });
   }
 

--- a/app/utils/slack/slackNotifications.js
+++ b/app/utils/slack/slackNotifications.js
@@ -45,7 +45,9 @@ function buildUrl(questionId) {
   return `https://${domain}/questions/${questionId}`;
 }
 
-async function createAnswerNotification({ questionId, questionBody, answerBody }) {
+async function createAnswerNotification({
+  questionId, questionBody, answerBody, is_public,
+}) {
   const url = buildUrl(questionId);
   const limit = SLACK_MAX_MESSAGE_SIZE_IN_BYTES;
 
@@ -83,6 +85,7 @@ async function createAnswerNotification({ questionId, questionBody, answerBody }
       color: SLACK_ANSWER_COLOR,
       pretext: SLACK_ANSWER_HEADER,
     },
+    is_public,
   };
 
   await send(options);

--- a/tests/integration/controllers/answers/createAnswer.test.js
+++ b/tests/integration/controllers/answers/createAnswer.test.js
@@ -60,7 +60,7 @@ describe('createAnswer', () => {
   it('does not send slack if question is not public', async () => {
     findUniqueSpy.mockResolvedValue({
       question_id: 123,
-      question_text: 'Example question',
+      question: 'Example question',
       is_public: false,
     });
 


### PR DESCRIPTION
#### What does this PR do?
-change the configuration to post the answer for anon question when is public

#### How should this be manually tested?
1. Pull this branch 
2. Run the project
3. Add the next environment variables `SLACK_WEBHOOK_URL`, `SLACK_WEBHOOK_URL_ADMIN` and `SLACK_WIZEQ_DOMAIN` if you don't have the values, send me a DM. 
4. Login as admin
5. Post anonymous question (you have to see one post in the slack channel #wize-q-dev)
6. Answer the anon question (you have to see one post in the slack channel #wize-q-dev)
7. Post normal question (you have to see 2 posts in the slack channel #wize-q-dev)
8. Answer normal question (you have to see 2 posts in the slack channel #wize-q-dev)
9. Post anonymous question (you have to see one post in the slack channel #wize-q-dev)
10. Publish the question (you have to see one post in the slack channel #wize-q-dev like the one in the step 9 )
11. Answer the anon question (you have to see 2 post in the slack channel #wize-q-dev)
12. :tada:

#### Any background context you want to provide?
- When the admins answer an anonymous question 

#### What are the relevant tickets?
(Link to issues, related PR, JIRA issues, etc.)
Closes #299 
