### PR TITLE
fix: issue 301 New lines are ignored in comments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 node_modules
-
+/.idea
 /.cache
 /build
 /public/build

--- a/app/components/QuestionComment/QuestionComment.jsx
+++ b/app/components/QuestionComment/QuestionComment.jsx
@@ -370,14 +370,14 @@ function QuestionComment({ commentData, onSubmitSuccess, ...props }) {
               </Styled.ButtonSeeComment>
               )}
               <Styled.QuestionCommentMarkdown
-                children={comment}
+                children={comment.replace(String.fromCharCode(10), '\n\n')}
                 components={{ link: MarkdownLinkRenderer }}
               />
             </Styled.QuestionCommentIsTagged>
           ) : (
             <Styled.QuestionCommentEdit>
               <CommentInputText
-                inputValue={comment}
+                inputValue={comment.replace(String.fromCharCode(10), '\n\n')}
                 placeholder={COMMENT_EDIT_PLACEHOLDER}
                 onInputChange={handleCommentUpdate}
               />


### PR DESCRIPTION
#### What does this PR do?
(A brief explanation synthesizing the feature, bug or fix.)
the LF character in the comments (char 10) is replaced with a breakline in react-markdown rendering

.replace(String.fromCharCode(10), '\n\n')

The double \n\n is needed in this library to render a  new ```<p>``` for each line.
