### PR TITLE
feat(infra): Add SA for WizePrompt team with read permissions on CloudSQL instances 

### DIFF
--- a/infrastructure/terraform/iam.tf
+++ b/infrastructure/terraform/iam.tf
@@ -1,0 +1,7 @@
+# CloudSQL Read Permissions for WizePrompt SA
+resource "google_project_iam_member" "wizeprompt__cloudsql__reader" {
+  role = "roles/cloudsql.viewer"
+  members = [
+    "serviceAccount:${google_service_account.wizeprompt.email}",
+  ]
+}

--- a/infrastructure/terraform/iam.tf
+++ b/infrastructure/terraform/iam.tf
@@ -1,6 +1,6 @@
 # CloudSQL Read Permissions for WizePrompt SA
 resource "google_project_iam_member" "wizeprompt__cloudsql__reader" {
-  project = var.project
+  project = "wizeline-questions"
   role = "roles/cloudsql.viewer"
   member = "serviceAccount:${google_service_account.wizeprompt.email}"
 }

--- a/infrastructure/terraform/iam.tf
+++ b/infrastructure/terraform/iam.tf
@@ -1,7 +1,6 @@
 # CloudSQL Read Permissions for WizePrompt SA
 resource "google_project_iam_member" "wizeprompt__cloudsql__reader" {
+  project = var.project
   role = "roles/cloudsql.viewer"
-  members = [
-    "serviceAccount:${google_service_account.wizeprompt.email}",
-  ]
+  member = "serviceAccount:${google_service_account.wizeprompt.email}"
 }

--- a/infrastructure/terraform/iam.tf
+++ b/infrastructure/terraform/iam.tf
@@ -1,6 +1,13 @@
 # CloudSQL Read Permissions for WizePrompt SA
 resource "google_project_iam_member" "wizeprompt__cloudsql__reader" {
   project = "wizeline-questions"
-  role = "roles/cloudsql.viewer"
-  member = "serviceAccount:${google_service_account.wizeprompt.email}"
+  role    = "roles/cloudsql.viewer"
+  member  = "serviceAccount:${google_service_account.wizeprompt.email}"
+}
+
+
+resource "google_project_iam_member" "wizeprompt__cloudsql__client" {
+  project = "wizeline-questions"
+  role    = "roles/cloudsql.client"
+  member  = "serviceAccount:${google_service_account.wizeprompt.email}"
 }

--- a/infrastructure/terraform/service-accounts.tf
+++ b/infrastructure/terraform/service-accounts.tf
@@ -1,0 +1,7 @@
+# Service Account for WizePrompt team to Connect to CloudSQL from AWS
+resource "google_service_account" "wizeprompt" {
+  display_name = "WizePrompt - CloudSQL Connect"
+  account_id   = "wizeprompt"
+  description  = "Allow WizePrompt team to connect to CloudSQL with read-only privileges"
+  disabled     = false
+}


### PR DESCRIPTION
What does this PR do?
Add new Service Account for WizePrompt Team
Grant that SA permissions to read all CloudSQL instances in WizeQ project
Where should the reviewer start?
Changes in Terraform File

How should this be manually tested?
Terraform Plan (TBD, configuring local env)

Any background context you want to provide?
WizePrompt team reached out to me about the SA

What are the relevant tickets?
None on WizeQ side