### PR TITLE
fix: set width of wrapper to 100%

### DIFF
--- a/app/components/ListQuestions/ListQuestions.Styled.jsx
+++ b/app/components/ListQuestions/ListQuestions.Styled.jsx
@@ -26,6 +26,7 @@ export const CenterWrapper = styled.div`
   flex: 2;
   display: flex;
   justify-content: center;
+  width: 100%;  
 `;
 
 export const RightWrapper = styled.div`


### PR DESCRIPTION
#### What does this PR do?
Currently the main container grows width to cover the content, no matters if the screen is not capable to contain it

![image](https://github.com/wizeline/wize-q-remix/assets/93023361/cb8f7f96-bc41-4a74-a959-e6e252bdad8b)

#### Where should the reviewer start?
you can run the project locally and test several mobile versions

#### Screenshots
![image](https://github.com/wizeline/wize-q-remix/assets/93023361/85acceb1-d85c-4f2b-9eff-f0ce5357185f)
